### PR TITLE
Several docs error correction.

### DIFF
--- a/docs/adoc/BookScoutInstallation.adoc
+++ b/docs/adoc/BookScoutInstallation.adoc
@@ -228,7 +228,7 @@ Note that some folders and many files of a Tomcat installation are not represent
 We just want to provide a basic understanding of the most important parts to operate the web server in the context of this book.
 In the [filename]+bin+ folder, the executable programs are contained, including scripts to start and stop the Tomcat instance.
 
-The [filename]+conf+ folder contains a set of XML and property configuration file.
+The [filename]+conf+ folder contains a set of XML and property configuration files.
 The file [filename]+server.xml+ represents Tomcat's main configuration file.
 It is used to configure general web server aspects such as the port number of its connectors for the client server communication.
 For the default setup, port number 8080 is used for the communication between clients applications and the web server.

--- a/docs/adoc/ExportTheApplication.adoc
+++ b/docs/adoc/ExportTheApplication.adoc
@@ -18,7 +18,7 @@ ifndef::mdledir[:mdledir: .]
 At some point during the application development you will want to install your software on a machine that is intended for productive use.
 This is the moment where you need to be able to build and package your Scout application in a way that can be deployed to an application server.
 
-As Scout applications just need a servlet container to run, Scout applications can be deployed to almost any Java appliction servers.
+As Scout applications just need a servlet container to run, Scout applications can be deployed to almost any Java appliction server.
 For the purpose of this tutorial we will use http://tomcat.apache.org/tomcat-8.0-doc/index.html[Apache Tomcat].
 
 ==== Verify the Container Security Settings
@@ -158,6 +158,6 @@ Then you will see the login page as shown in <<img-helloworld_running_download>>
 You can find this configuration in the [filename]+config.properties+ file of the application.
 
 Please note: In a productive environment it is recommended to deploy the server and the user interface into two different servlet containers running on dedicated machines.
-This because these two tiers have different requirements on resources, load balancing and access protection.
+This is because these two tiers have different requirements on resources, load balancing and access protection.
 Furthermore, it is strongly recommended to use an encrypted connection (e.g. TLS 1.2 footnote:[TLS: https://en.wikipedia.org/wiki/Transport_Layer_Security])
-between client browsers and the Scout frontend server AND between the Scout frontend and and backend server!
+between client browsers and the Scout frontend server AND between the Scout frontend and backend server!

--- a/docs/adoc/SdkContentAssist.adoc
+++ b/docs/adoc/SdkContentAssist.adoc
@@ -20,7 +20,7 @@ The offered proposals are context specific.
 Depending on the current cursor position in the Java editor, possible Scout components are added to the proposal list. 
 
 In a class representing a group box in a form, the Scout content assist adds proposals for various form fields are shown and in a table class the content assist adds proposals to add table columns or context menus. 
-are added that trigger the creation of inner classes for form fields, table columns or codes.
+Those proposals trigger the creation of inner classes for form fields, table columns or codes.
 The Eclipse content assist can be started by typing kbd:[Ctrl,Space]. 
 
 [[sec-sdk_new_form_field]]
@@ -34,7 +34,7 @@ Typing kbd:[Ctrl,Space] then provides access to the most frequently used Scout w
 .Proposals to create new form fields in a GroupBox
 image::{imgsdir}/java_proposals_groupbox2.png[]
 
-When a template is selected, it is possible to customized it by navigating between the different Edit-Groups with the kbd:[Tab] Key (this works exactly like other templates in the Eclipse Editor).
+When a template is selected, it is possible to customize it by navigating between the different Edit-Groups with the kbd:[Tab] Key (this works exactly like other templates in the Eclipse Editor).
 With this mechanism you can quickly define the class name, the parent class and other properties.
 To exit the Edit-Mode just press kbd:[Enter].
 

--- a/docs/adoc/SdkEditorNls.adoc
+++ b/docs/adoc/SdkEditorNls.adoc
@@ -57,7 +57,7 @@ Import and Export requires additional components.
 
 Hide inherited rows checkbox
 
-On the top of each columns, the text fields allow you to filter the entries in the table.
+On the top of each column, the text fields allow you to filter the entries in the table.
 With the btn:[Reset] button on the right you will empty those filters.
 
 The entries in the table can be directly edited by pressing F2 or double-clicking into a text cell.
@@ -80,7 +80,7 @@ On each row it is possible to call following context menu:
 | Delete the NLS Entry from the files
 |===
 
-==== Default Mapping to Property Files
+==== Default Mapping to Properties Files
 
 The mapping between the properties files is registered in the "Text Provider Service" class.
 Per default the files follow this pattern:

--- a/docs/adoc/SdkWizardPage.adoc
+++ b/docs/adoc/SdkWizardPage.adoc
@@ -34,7 +34,7 @@ The context can be derived from a package selected in the Package Explorer or fr
 
 Source Folder:: The source folder of the Maven client module used for the creation of the page. The default value is the `src/main/java` folder in the Maven client module.
 Package:: The Java package that will contain the page class. The Scout SDK will try to guess the package name from the current context and derive matching package names for the Maven shared module.
-Name:: The name of the page class. According to Scout conventions the class name ends with the suffix `Page`.
+Name:: The name of the page class. According to Scout conventions the class name ends with the suffix `TablePage` (for subclasses of `AbstractPageWithTable`) or `NodePage` (for `AbstractPageWithNodes`).
 Super Class:: The super class for the form. `AbstractPageWithTable` is the default value.
 Shared Source Folder:: The source folder of the Maven shared module used for creation of the page data and the service interface. The default value is the `src/main/java` folder in the Maven shared module.
 Server Source Folder:: The source folder of the Maven server module used for creation of the service implementation. The default value is the `src/main/java` folder in the Maven server module.
@@ -43,9 +43,9 @@ Server Source Folder:: The source folder of the Maven server module used for cre
 In the <<img-sdk_wizard_page>> example shown above the Scout SDK will create the following components.
 
 * In Maven module *helloworld.client*
-** The `MyPage` page class in folder `src/main/java` and package `org.eclipse.scout.apps.helloworld.client.helloworld`
+** The `MyTablePage` page class in folder `src/main/java` and package `org.eclipse.scout.apps.helloworld.client.helloworld`
 * In Maven module *helloworld.shared* 
 ** The `IMyService` service interface in folder `src/main/java` and package `org.eclipse.scout.apps.helloworld.shared.helloworld`
-** `MyPageData` page data class in folder `src/generated/java` and package `org.eclipse.scout.apps.helloworld.shared.helloworld`
+** `MyTablePageData` page data class in folder `src/generated/java` and package `org.eclipse.scout.apps.helloworld.shared.helloworld`
 * In Maven module *helloworld.server* 
 ** The `MyService` implementation in folder `src/main/java` and package `org.eclipse.scout.apps.helloworld.server.helloworld`

--- a/docs/adoc/SdkWizardProject.adoc
+++ b/docs/adoc/SdkWizardProject.adoc
@@ -51,16 +51,16 @@ Using the default artifact Id *helloworld* the following Maven modules are creat
 ** The class `HelloWorldForm` in package `org.eclipse.scout.apps.helloworld.client.helloworld` is an example of a model class.
 * Maven module *helloworld.shared* 
 ** Contains components needed in both the client and the server application.
-** For examples see the `IHelloWorldFormService` interface in `src/main/java` and class `HelloWorldFormData` in `src/generated/java`.
+** For examples see the `IHelloWorldService` interface in `src/main/java` and class `HelloWorldFormData` in `src/generated/java`.
 ** The `Texts.nls` file that can be opened in the {sdk_editor_nls}.
 * Maven module *helloworld.server* 
 ** Contains the model components of the server application in `src/main/java` and model tests in `src/test/java`.
-** The class `HelloWorldFormService` in package `org.eclipse.scout.apps.helloworld.server.helloworld` is an example of such a model class.
+** The class `HelloWorldService` in package `org.eclipse.scout.apps.helloworld.server.helloworld` is an example of such a model class.
 * Maven module *helloworld.server.app.dev* 
 ** Contains all components to run the Scout server application from within the Eclipse IDE.
 ** The file `config.properties` in folder `src/main/resources` contains the development configuration for the Scout server application.
 ** The file `pom.xml` bundles the Jetty web server with the server application.
-** The file `server-dev.launch` contains the launch configuration for the Eclipse IDE.
+** The file `[webapp] dev server.launch` contains the launch configuration for the Eclipse IDE.
 * Maven module *helloworld.server.app.war*
 ** Contains all components to create a Scout server WAR file to deploy to an external web server.
 ** The file `config.properties` in folder `src/main/resources` contains the server configuration.
@@ -73,7 +73,7 @@ Using the default artifact Id *helloworld* the following Maven modules are creat
 ** The file `config.properties` in folder `src/main/resources` contains the development configuration for the application.
 ** The file `web.xml` in folder `src/main/webapp` contains the web configuration for the application.
 ** The file `pom.xml` bundles the Jetty web server with the application.
-** The file `ui-html-dev.launch` contains the launch configuration for the Eclipse IDE.
+** The file `[webapp] dev ui.launch` contains the launch configuration for the Eclipse IDE.
 * Maven module *helloworld.ui.html.app.war* 
 ** Contains all components to create a Scout UI WAR file to deploy to an external web server.
 ** The file `config.properties` in folder `src/main/resources` contains the application configuration.

--- a/docs/build/beginners_guide/src/docs/_OneDayTutorial.adoc
+++ b/docs/build/beginners_guide/src/docs/_OneDayTutorial.adoc
@@ -19,7 +19,7 @@ ifndef::mdledir[:mdledir: ../../../../adoc]
 == A One Day Tutorial
 
 In this chapter we will create the "`Contacts`" Scout application. 
-The goal of this tutorial application is to learn about the most prominent features of the Eclipse Scout framework using a fully functioning application. 
+The goal of this tutorial application is to learn about the most prominent features of the Eclipse Scout framework using a fully functional application. 
 
 The application is kept small enough to complete this tutorial within less than a day.
 An extended version of "`Contacts`" is available as a Scout sample application on https://github.com/BSI-Business-Systems-Integration-AG/org.eclipse.scout.docs/tree/releases/6.0.x/code/contacts[Github].

--- a/docs/build/beginners_guide/src/docs/_ScoutTooling.adoc
+++ b/docs/build/beginners_guide/src/docs/_ScoutTooling.adoc
@@ -190,7 +190,7 @@ In the first wizard step type "_Scout_" into the *Wizards* field as shown in <<i
 .Selecting Scout Wizards in the Eclipse wizard dialog
 image::{imgsdir}/sdk_new_wizard.png[]
 
-The Wizards provided by the Scout SDK are introduced and described in the sections listed below.
+The wizards provided by the Scout SDK are introduced and described in the sections listed below.
 
 * <<sec-wizard_project>>
 * <<sec-wizard_page>>

--- a/docs/build/beginners_guide/src/docs/_TutorialIntro.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialIntro.adoc
@@ -74,7 +74,7 @@ The covered topics includes dealing with application properties, setup and acces
 
 Step 4: <<sec-contacts_forms>>:: 
 Having access to the database is used in this step to add the components that allow a user to create and edit persons in the user interface of the "Contacts" application.
-In addition, this tutorial steps also demonstrates how to design and implement complex form layouts with the Scout framework.   
+In addition, this tutorial step also demonstrates how to design and implement complex form layouts with the Scout framework.   
 
 Step 5: <<sec-contacts_fields>>:: 
 This step provides an introduction into form field validation and the creation of template fields.

--- a/docs/build/beginners_guide/src/docs/_TutorialStep1.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialStep1.adoc
@@ -76,7 +76,7 @@ For this, we perform the following modifications to class `WorkOutline`.
 
 * Rename the class package to `org.eclipse.scout.contacts.client.contact`
 * Rename the class to `ContactOutline`
-* Change the outline title to "Contact"
+* Change the outline title to "Contacts"
 * Change the outline icon to `Icons.Category`
 
 To quickly find class `WorkOutline` we first open the [wizard]_Open Type_ dialog from the Eclipse IDE by hitting kbd:[Ctrl+Shift+T] and enter "workoutline" into the search field as shown in <<img-eclipse_open_type>>.
@@ -111,7 +111,7 @@ To enter a new translated text we double click on the proposal [element]_New tex
 
 [[img-sdk_new_text_entry_contact_wizard, Figure 000]]
 image::{imgsdir}/sdk_new_text_entry_contact_wizard.png[]
-.The Scout new entry wizard to add translated texts to the application.
+.Use the Scout new entry wizard to add translated texts to the application.
 
 As the last modification we change the return value of method `getConfiguredIconId` to value `Icons.Category` and end with the code shown in <<lst-contacts_outline>>.
 
@@ -147,7 +147,7 @@ Then, perform the following changes in class `Desktop`
 
 * Delete inner class `SettingOutlineViewButton`
 * Rename inner class WorkOutlineViewButton to `ContactOutlineViewButton`
-* Rename FileMenu to `QuickAccessMenu`, let `getConfiguredText` return "Quick Access" and delete the remaining content.
+* Rename FileMenu to `QuickAccessMenu`, let `getConfiguredText` return "QuickAccess" and delete the remaining content.
 * Rename BookmarkMenu to `OptionsMenu`. Add methods `getConfiguredText` and  `getConfiguredIconId` according to <<lst-contacts_desktop>>.
 * Change HelpMenu to `UserMenu`. Remove method `getConfiguredText` and add method `getConfiguredIconId` that returns `AbstractIcons.Person`.
 
@@ -173,9 +173,9 @@ To disable the theming property follow the steps described below.
 
 . Expand the module `org.eclipse.scout.contacts.ui.html.app.dev` in the Eclipse package explorer
 . Expand folder `src/main/resources`
-. Open file `config.property` in a text editor
+. Open file `config.properties` in a text editor
 . Comment out property `scout.ui.theme` as shown in <<lst-contacts_theming_property>>
-. Save the modified property file
+. Save the modified properties file
 
 [[lst-contacts_theming_property, Listing theming property]]
 [source]
@@ -202,7 +202,7 @@ The user interface of the application will now look as shown in <<img-contacts_t
 
 * Start the backend application
 * Start the frontend application
-* Open address in your http://localhost:8082/[http://localhost:8082/] browser
+* Open address http://localhost:8082/[http://localhost:8082/] in your browser
 
 [[img-contacts_tutorial_result_step_1, Figure 000]]
 .The "Contacts" application at the end of tutorial step 1.

--- a/docs/build/beginners_guide/src/docs/_TutorialStep2.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialStep2.adoc
@@ -3,7 +3,7 @@
 //-----------------------------------------------------------------------------
 
 In the second step of the Scout tutorial the components to display persons and organizations are added to the "Contacts" outline of the user interface of the Scout application.
-Specifically, a "Persons" page and an "Organizations" page are created and added to navigation tree of the "Contacts" outline.
+Specifically, a "Persons" page and an "Organizations" page are created and added to the navigation tree of the "Contacts" outline.
 
 Database access and populating the pages with actual data from the database is not part of this section but will be covered in section <<sec-contacts_jdbc>> in the next tutorial step.
 
@@ -80,7 +80,7 @@ We can now add the Scout person page as described below.
 .Add the person page to the "Contacts" application.
 image::{imgsdir}/sdk_new_personpage_wizard.png[]
 
-The Scout [wizard]_New Page Wizard_ then creates an initial implementation for the `PersonTable` class very similar to the listing provided in <<lst-contacts_PersonTable>> below.
+The Scout [wizard]_New Page Wizard_ then creates an initial implementation for the `PersonTablePage` class very similar to the listing provided in <<lst-contacts_PersonTable>> below.
 
 [[lst-contacts_PersonTable, Listing PersonTablePage]]
 [source,java]
@@ -103,7 +103,7 @@ We are now ready to populate the inner class `Table` of the person page with the
 
 Table pages are an important UI element of Scout applications as they frequently play a central role in the interactions of a user with the application.
 Out of the box table pages offer powerful options to sort, filter and re-arrange the data contained in the table.
-This functionality offers a good starting point to decide on the columns to add to a table page.
+This functionality offers a good starting point to decide which columns to add to a table page.
 
 To decide the columns to add the following criterias have been useful in practice.
 
@@ -170,7 +170,7 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.client/src/main/java/org/
 
 For column `CountryColumn` we will use a smart column.
 We again use kbd:[Ctrl+Space] to open the wizard and enter "Country" for the class name box and press kbd:[Tab] once and select [element]_AbstractSmartColumn_ as column type.
-Next we press kbd:[Tab] again to enter "City" as the translated text.
+Next we press kbd:[Tab] again to enter "Country" as the translated text.
 
 In the created class `CountryColumn` we need to update the class to extend `AbstractSmartColumn<String>` and add the method `getConfiguredLookupCall` according to <<lst-contacts_CountryColumn>>.
 
@@ -221,7 +221,7 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.client/src/main/java/org/
 
 <1> A new instance of the `PersonTable` is added to this outline. This makes the person page visible in the navigation area below the contacts outline.
 
-Before we can save the class `ContactOutline` we have to update its imports to include the import statement for class `PersonTable`.
+Before we can save the class `ContactOutline` we have to update its imports to include the import statement for class `PersonTablePage`.
 To update the imports you can either user the menu menu:Source[Organize Imports] or use the keyboard shortcut kbd:[Ctrl+Shift+O].
 
 The application is now in a state where we can restart the backend and the frontend server to verify our changes in the user interface.
@@ -274,7 +274,7 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.client/src/main/java/org/
 In the second step of the "Contacts" tutorial we have created a person page and an organization page to display data of persons and organizations.
 
 The "Contacts" application is in a clean state again and you can (re)start the backend and the frontend of the application and verify the user interface in your browser.
-The user interface should the look as the screenshot provided in <<img-contacts_tutorial_result_step_2>>.
+The user interface should look like the screenshot provided in <<img-contacts_tutorial_result_step_2>>.
 
 [[img-contacts_tutorial_result_step_2, Figure 000]]
 .The "Contacts" application with the person and organization pages at the end of tutorial step 2.

--- a/docs/build/beginners_guide/src/docs/_TutorialStep3.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialStep3.adoc
@@ -142,12 +142,12 @@ To change the setup to a disk based version, we would have to change the value f
 from `jdbc:derby:memory:contacts-database` to `jdbc:derby:<path-to-dir>`. 
 For a Windows box a concrete example could look like this: `jdbc:derby:c:\\derby\\contacts-database`. 
 
-We now look at how the actual SQL statements of the "Contacts" application. 
+Now we look at how the actual SQL statements of the "Contacts" application work. 
 For our application all statements are collected into a single class.  
 While there are many more options how to organize SQL and Java code this setup has its own advantages. 
 
 * Efficient maintenance as all SQL statements are located in a single place
-* Code completion support in the Eclispe IDE when using the statements    
+* Code completion support in the Eclipse IDE when using the statements    
 * The setup is easy to explain
 
 The SQL statements related to the database structure are provided in <<lst-contacts_sql_createdb>>. 

--- a/docs/build/beginners_guide/src/docs/_TutorialStep4.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialStep4.adoc
@@ -27,10 +27,10 @@ image::{imgsdir}/contacts_person_form.png[]
 The upper half of the form shows a picture of the person and contains some primary attributes such as first name and the gender of the person. 
 
 The lower half of the form contains tab boxes. 
-A "Details" tab provides contact details of the person and adding notes for the person in the form of free text is possible in the "Comments" tab.
+A "Contact Info" tab provides contact details of the person and adding notes for the person in the form of free text is possible in the "Notes" tab.
 
 <<img-contacts_person_form_grid>> below shows how the sketched form can fit with the logical grid layout of the Scout framework. 
-Scout containers have two columns (indicated in red) per default and as many rows (indicated in yellow) as are needed. 
+Scout containers have two columns (indicated in red) per default and as many rows (indicated in yellow) as needed. 
 
 [[img-contacts_person_form_grid, Figure 000]]
 .Logical columns and rows of the Scout form layout. Scout containers have two columns per default.

--- a/docs/build/beginners_guide/src/docs/_TutorialStep6.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialStep6.adoc
@@ -57,9 +57,9 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.server/src/main/java/org/
 ----
 
 Method `prepareCreate` is not needed for the creation of a new organization and we can remove it from `OrganizationService` and `IOrganizationService`. 
-Therefore, the implementation of the method `execLoad` in the new handler of the organization form can be removed also.  
+Therefore, the implementation of the method `execLoad` in the new handler of the organization form can also be removed.  
 
-With these implementation of the organization form and organization service the "Contacts" application can now also be used to maintain a list of organizations. 
+With these implementations of the organization form and organization service the "Contacts" application can now also be used to maintain a list of organizations. 
 
 [[sec-contacts_form_rest_summary]]
 ==== What have we achieved?

--- a/docs/build/beginners_guide/src/docs/_TutorialStep7.adoc
+++ b/docs/build/beginners_guide/src/docs/_TutorialStep7.adoc
@@ -71,9 +71,9 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.server/src/main/java/org/
 
 <1> We only need to return a single SQL statement for lookup services that extend `AbstractSqlLookupService`
 
-The SQL statment that backs the lookup service is provided in <<lst-contacts_lookup_service_sql>>. 
+The SQL statement that backs the lookup service is provided in <<lst-contacts_lookup_service_sql>>. 
 Lookup services can provide data for three different use cases. 
-The most straight forward case is the mapping of a key to a specific lookup row. 
+The most straightforward case is the mapping of a key to a specific lookup row. 
 Next is the case where the lookup service returns a number of lookup rows that match a provided substring and finally the case where the lookup service simply returns all available rows. 
 
 [[lst-contacts_lookup_service_sql, Listing SQL.ORGANIZATION_LOOKUP]]
@@ -90,7 +90,7 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.server/src/main/java/org/
 [[sec-contacts_modify_person_form_and_page]]
 ==== Using the Lookup Call in the Person Form and the Person Table
 
-We can now use the organization lookup call to transform the organization field in the "Work" tab of the person form into a smart field. 
+Now we can use the organization lookup call to transform the organization field in the "Work" tab of the person form into a smart field. 
 To do this we open class `PersonForm` in the Java editor and navigate to its inner class `WorkBox`. 
 Then, update the implementation of the OrganizationField according to <<lst-contacts_organization_smart_field>> 
 
@@ -104,7 +104,7 @@ include::{codedir}/contacts/org.eclipse.scout.contacts.client/src/main/java/org/
 <1> The OrganizationField now extends a Scout smart field  
 <2> The smart field is backed by the newly created organization lookup call
 
-This change has the effect, that we can now assign an organization in the person form by typing a substring of the organizations name into the organization field. 
+This change has the effect, that now we can assign an organization in the person form by typing a substring of the organizations name into the organization field. 
 The conversion of the field into a smart field has the additional benefit that only valid organizations can be selected that respect the referential integrity defined by the database. 
 
 As a next step we also modify the organization column of the person page. 
@@ -262,7 +262,7 @@ To implement a drill-down functionality for the organization table we have creat
 To link the two table pages we have also created and integrated a Scout node page.
 
 The "Contacts" application is in a clean state again and you can (re)start the backend and the frontend of the application and verify the result in your browser. 
-As shown in <<img-contacts_tutorial_result_step_7>> the organizaion specific person data is now presented in a hierarchical form in the navigation area of the application. 
+As shown in <<img-contacts_tutorial_result_step_7>> the organization specific person data is now presented in a hierarchical form in the navigation area of the application. 
 
 [[img-contacts_tutorial_result_step_7, Figure 000]]
 .The linked person page only shows person related to the parent organization page.


### PR DESCRIPTION
- "server" instead of "servers"
- word "is" is missing
- duplicated "and"
- "Wizards" to lower case
- "IHelloWorldService" instead of "IHelloWorldFormService" (interface
IHelloWorldFormService does not exist)
- "HelloWorldService" instead of "HelloWorldFormService" (class
HelloWorldFormService does not exist)
- "[webapp] dev server.launch" instead of "server-dev.launch" (outdated)
- "[webapp] dev ui.launch" instead of "ui-html-dev.launch" (outdated)
- "TablePage" instead of "Page"
- "MyTablePage" instead of "MyPage"
- "MyTablePageData" instead of "MyPageData"
- rephrase sentence "are added that trigger..."
- "customize" instead of "customized"
- "column" instead of "columns"
- "Properties" instead of "Property" (like the text below)
- "functional" instead of "functioning"
- "step" instead of "steps"
- "Contacts" instead of "Contact"
- rephrase sentence "The Scout new entry..."
- "QuickAccess" instead of "Quick Access"
- "config.properties" instead of "config.property"
- "properties" instead of "property"
- rephrase sentence "Open address in your http://localhost:8082/
browser"
- word "the" is missing
- "PersonTablePage" instead of "PersonTable" (class PersonTable does not
exist)
- "which" instead of "on the"
- "Country" instead of "City"
- "PersonTablePage" instead of "PersonTable"
- rephrase sentence "should the look as the..."
- word "work" is missing
- rephrase sentence "We now look at how..."
- "Eclipse" instead of "Eclispe"
- "Contact Info" instead of "Details"
- "Notes" instead of "Comments"
- "as needed" instead of "as are needed"
- rephrase sentence "... can be removed also."
- "implementations" instead of "implementation"
- "statement" instead of "statment"
- "straightforward" instead of "straight forward"
- rephrase sentence "We can now use..."
- rephrase sentence "...that we can now..."
- "organization" instead of "organizaion"
- "files" instead of "file"