### PR TITLE
On 64 bit Linux os.arch can be either x86_64 or amd64

### DIFF
--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app.selenium/pom.xml
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app.selenium/pom.xml
@@ -140,6 +140,20 @@
       <activation>
         <os>
           <family>unix</family>
+          <arch>amd64</arch>
+        </os>
+      </activation>
+      <properties>
+        <chromedriver_url>${chromedriver_base_url}/chromedriver_linux64.zip</chromedriver_url>
+        <chromedriver_md5>${chromedriver_hash_linux64}</chromedriver_md5>
+        <webdriver.chrome.driver>${seleniumDrivers}/chromedriver</webdriver.chrome.driver>
+      </properties>
+    </profile>
+    <profile>
+      <id>linux64_chrome_driver</id>
+      <activation>
+        <os>
+          <family>unix</family>
           <arch>x86_64</arch>
         </os>
       </activation>


### PR DESCRIPTION
Not copying the whole profile would be more elegant, but maven currently doesn't support multiple activations with OR logic.