### PR TITLE
Fix some missing methods in OptionsMenu and UserMenu for chapter 4.3.4

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/Desktop.java
+++ b/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/Desktop.java
@@ -188,6 +188,7 @@ public class Desktop extends AbstractDesktop {
     }
     //tag::quickAccessMenu[]
     //tag::DesktopInit[]
+
   }
   //end::quickAccessMenu[]
 
@@ -204,6 +205,7 @@ public class Desktop extends AbstractDesktop {
     protected String getConfiguredIconId() {
       return AbstractIcons.Gear;
     }
+
     //end::DesktopInit[]
 
     //end::OptionsMenu[]
@@ -211,13 +213,14 @@ public class Desktop extends AbstractDesktop {
     protected String getConfiguredKeyStroke() {
       return IKeyStroke.F11;
     }
+    //tag::OptionsMenu[]
 
+    //tag::DesktopInit[]
     @Override
     protected Class<OptionsForm> getConfiguredForm() {
       return OptionsForm.class;
     }
-    //tag::OptionsMenu[]
-    //tag::DesktopInit[]
+
   }
   //end::OptionsMenu[]
 
@@ -228,6 +231,7 @@ public class Desktop extends AbstractDesktop {
     protected String getConfiguredIconId() {
       return AbstractIcons.Person;
     }
+
     //end::DesktopInit[]
 
     @Override
@@ -240,11 +244,12 @@ public class Desktop extends AbstractDesktop {
       setText(ISession.CURRENT.get().getUserId());
     }
 
+    //tag::DesktopInit[]
     @Override
     protected Class<UserForm> getConfiguredForm() {
       return UserForm.class;
     }
-    //tag::DesktopInit[]
+
   }
   //tag::quickAccessMenu[]
 }

--- a/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/Desktop.java
+++ b/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/Desktop.java
@@ -207,7 +207,6 @@ public class Desktop extends AbstractDesktop {
     }
 
     //end::DesktopInit[]
-
     //end::OptionsMenu[]
     @Override
     protected String getConfiguredKeyStroke() {


### PR DESCRIPTION
There were some missing methods in the classes OptionsMenu and UserMenu which lead to a compile error for the ones making the tutorial and **not** seeing the full source code. (I was beeing able to solve the problem by comparing my Desktop.java class with the one on Github).