### PR TITLE
Fixes typo in listing reference.

### DIFF
--- a/docs/adoc/technicalGuide/RunContext.adoc
+++ b/docs/adoc/technicalGuide/RunContext.adoc
@@ -23,7 +23,7 @@ By default, a `RunContext` is associated with a `RunMonitor`, and the monitor's 
 === Factory methods to create a RunContext
 Typically, a `RunContext` is created from a respective factory like `RunContexts` to create a `RunContext`, or `ServerRunContexts` to create a `ServerRunContext`, or `ClientRunContexts` to create a `ClientRunContext`. Internally, the `BeanManager` is asked to provide a new instance of the `RunContext`, which allows you to replace the default implementation of a `RunContext` in an easy way. The factories declare two factory methods: `empty()` and `copyCurrent()`. Whereas `empty()` provides you an empty `RunContext`, `copyCurrent()` takes a snapshot of the current calling context and initializes the `RunContext` accordingly. That is useful if only some few values are to be changed, or, if using `ServerRunContext`, to run the code on behalf of a new transaction.
 
-The following <<lst-RunContexts.copyCurrent>> illustrates the creation of an empty `RunContext` initialized with a particular `Subject` and `Locale`.
+The following <<lst-RunContexts.empty>> illustrates the creation of an empty `RunContext` initialized with a particular `Subject` and `Locale`.
 [[lst-RunContexts.empty]]
 [source,java,indent=0]
 .Creation of an empty `RunContext`


### PR DESCRIPTION
The listing _lst-RunContexts.copyCurrent_ was referenced twice, the listing _lst-RunContexts.empty_ was not referenced.

Signed-off-by: Michael Iseli <michael.iseli@bsi-software.com>