### PR TITLE
Fix pnpm version constraints in build scripts and include dev modules

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.ui.html/[contacts] js build.cmd
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html/[contacts] js build.cmd
@@ -19,7 +19,7 @@ if %errorlevel% neq 0 (
 
 :: Install pnpm
 echo Installing 'pnpm' into ../../node_modules
-call npm install pnpm@">=4.0.0 <5.0.0" --prefix ../../node_modules
+call npm install pnpm@">=5.0.0 <6.0.0" --prefix ../../node_modules
 echo.
 
 :: Install all JavaScript dependencies defined in the package.json => creates the node_modules folder

--- a/code/contacts/org.eclipse.scout.contacts.ui.html/[contacts] js build.sh
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html/[contacts] js build.sh
@@ -15,7 +15,7 @@ command -v npm >/dev/null 2>&1 || { echo >&2 "npm cannot be found. Make sure Nod
 
 # Install pnpm
 echo Installing 'pnpm' into ../../node_modules
-npm install pnpm@">=4.0.0 <5.0.0" --prefix "../../"
+npm install pnpm@">=5.0.0 <6.0.0" --prefix "../../"
 echo
 
 # Install all JavaScript dependencies defined in the package.json => creates the node_modules folder

--- a/code/contacts/org.eclipse.scout.contacts/pom.xml
+++ b/code/contacts/org.eclipse.scout.contacts/pom.xml
@@ -37,8 +37,10 @@
     <module>../org.eclipse.scout.contacts.client</module>
     <module>../org.eclipse.scout.contacts.shared</module>
     <module>../org.eclipse.scout.contacts.server</module>
+    <module>../org.eclipse.scout.contacts.server.app.dev</module>
     <module>../org.eclipse.scout.contacts.server.app.war</module>
     <module>../org.eclipse.scout.contacts.ui.html</module>
+    <module>../org.eclipse.scout.contacts.ui.html.app.dev</module>
     <module>../org.eclipse.scout.contacts.ui.html.app.war</module>
 
     <!-- Events module -->

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/[jswidgets] js build.cmd
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/[jswidgets] js build.cmd
@@ -19,7 +19,7 @@ if %errorlevel% neq 0 (
 
 :: Install pnpm
 echo Installing 'pnpm' into ../../node_modules
-call npm install pnpm@">=4.0.0 <5.0.0" --prefix ../../node_modules
+call npm install pnpm@">=5.0.0 <6.0.0" --prefix ../../node_modules
 echo.
 
 :: Install all JavaScript dependencies defined in the package.json => creates the node_modules folder

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/[jswidgets] js build.sh
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/[jswidgets] js build.sh
@@ -15,7 +15,7 @@ command -v npm >/dev/null 2>&1 || { echo >&2 "npm cannot be found. Make sure Nod
 
 # Install pnpm
 echo Installing 'pnpm' into ../../node_modules
-npm install pnpm@">=4.0.0 <5.0.0" --prefix "../../"
+npm install pnpm@">=5.0.0 <6.0.0" --prefix "../../"
 echo
 
 # Install all JavaScript dependencies defined in the package.json => creates the node_modules folder

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app/[widgets] js build.cmd
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app/[widgets] js build.cmd
@@ -19,7 +19,7 @@ if %errorlevel% neq 0 (
 
 :: Install pnpm
 echo Installing 'pnpm' into ../../node_modules
-call npm install pnpm@">=4.0.0 <5.0.0" --prefix ../../node_modules
+call npm install pnpm@">=5.0.0 <6.0.0" --prefix ../../node_modules
 
 :: Install all JavaScript dependencies defined in the package.json => creates the node_modules folder
 call cd ..\..

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app/[widgets] js build.sh
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app/[widgets] js build.sh
@@ -15,7 +15,7 @@ command -v npm >/dev/null 2>&1 || { echo >&2 "npm cannot be found. Make sure Nod
 
 # Install pnpm
 echo Installing 'pnpm' into ../../node_modules
-npm install pnpm@">=4.0.0 <5.0.0" --prefix "../../"
+npm install pnpm@">=5.0.0 <6.0.0" --prefix "../../"
 echo
 
 # Install all JavaScript dependencies defined in the package.json => creates the node_modules folder

--- a/code/widgets/org.eclipse.scout.widgets/pom.xml
+++ b/code/widgets/org.eclipse.scout.widgets/pom.xml
@@ -38,6 +38,7 @@
     <module>../org.eclipse.scout.widgets.shared</module>
     <module>../org.eclipse.scout.widgets.ui.html</module>
     <module>../org.eclipse.scout.widgets.ui.html.app</module>
+    <module>../org.eclipse.scout.widgets.ui.html.app.dev</module>
     <module>../org.eclipse.scout.widgets.ui.html.app.war</module>
 
     <!-- Scout JS widgets -->


### PR DESCRIPTION
Scout now requires at least pnpm 5.
Dev modules need to be in parent pom to make sure they are imported
into the IDE.