### PR TITLE
Improve LabelFieldForm

### DIFF
--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/HtmlFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/HtmlFieldForm.java
@@ -193,6 +193,31 @@ public class HtmlFieldForm extends AbstractForm implements IAdvancedExampleForm 
         return TriState.FALSE;
       }
 
+      @Order(5)
+      @ClassId("99e3f0b2-92b5-4cab-b102-750beefd6bf1")
+      public class SelectableField extends AbstractBooleanField {
+
+        @Override
+        protected String getConfiguredLabel() {
+          return "Selectable";
+        }
+
+        @Override
+        protected boolean getConfiguredLabelVisible() {
+          return false;
+        }
+
+        @Override
+        protected void execChangedValue() {
+          getHtmlField().setSelectable(isChecked());
+        }
+
+        @Override
+        protected void execInitField() {
+          setChecked(getHtmlField().isSelectable());
+        }
+      }
+
       @Order(10)
       @ClassId("79efda24-776b-477c-9eec-5dd53704a566")
       public class ScrollBarEnabledField extends AbstractBooleanField {

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/LabelFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/LabelFieldForm.java
@@ -10,17 +10,26 @@
  */
 package org.eclipse.scout.widgets.client.ui.forms;
 
+import org.eclipse.scout.rt.client.ui.action.menu.AbstractMenu;
 import org.eclipse.scout.rt.client.ui.form.AbstractForm;
 import org.eclipse.scout.rt.client.ui.form.AbstractFormHandler;
+import org.eclipse.scout.rt.client.ui.form.fields.IValueField;
+import org.eclipse.scout.rt.client.ui.form.fields.booleanfield.AbstractBooleanField;
+import org.eclipse.scout.rt.client.ui.form.fields.button.AbstractButton;
 import org.eclipse.scout.rt.client.ui.form.fields.button.AbstractCloseButton;
 import org.eclipse.scout.rt.client.ui.form.fields.groupbox.AbstractGroupBox;
 import org.eclipse.scout.rt.client.ui.form.fields.labelfield.AbstractLabelField;
+import org.eclipse.scout.rt.client.ui.form.fields.labelfield.ILabelField;
+import org.eclipse.scout.rt.client.ui.form.fields.stringfield.AbstractStringField;
 import org.eclipse.scout.rt.client.ui.messagebox.MessageBoxes;
 import org.eclipse.scout.rt.platform.Order;
 import org.eclipse.scout.rt.platform.classid.ClassId;
 import org.eclipse.scout.rt.platform.html.HTML;
 import org.eclipse.scout.rt.platform.text.TEXTS;
 import org.eclipse.scout.widgets.client.ui.forms.LabelFieldForm.MainBox.CloseButton;
+import org.eclipse.scout.widgets.client.ui.forms.LabelFieldForm.MainBox.FormFieldPropertiesBox;
+import org.eclipse.scout.widgets.client.ui.forms.LabelFieldForm.MainBox.LabelFieldBox.LabelField;
+import org.eclipse.scout.widgets.client.ui.forms.fields.formfield.AbstractFormFieldPropertiesBox;
 
 @ClassId("6d611416-0959-41d6-9230-44cf6bcdc102")
 public class LabelFieldForm extends AbstractForm implements IPageForm {
@@ -45,6 +54,27 @@ public class LabelFieldForm extends AbstractForm implements IPageForm {
     return getFieldByClass(CloseButton.class);
   }
 
+  public LabelField getLabelField() {
+    return getFieldByClass(LabelField.class);
+  }
+
+  public FormFieldPropertiesBox getFormFieldPropertiesBox() {
+    return getFieldByClass(FormFieldPropertiesBox.class);
+  }
+
+  protected <T> void setValueWithoutValueChangeTriggers(IValueField<T> valueField, T value) {
+    if (valueField.isValueChanging()) {
+      return;
+    }
+    valueField.setValueChangeTriggerEnabled(false);
+    try {
+      valueField.setValue(value);
+    }
+    finally {
+      valueField.setValueChangeTriggerEnabled(true);
+    }
+  }
+
   @Order(10)
   @ClassId("ab93271a-d9b7-44d8-acc5-32b1c5215f8d")
   public class MainBox extends AbstractGroupBox {
@@ -55,75 +85,26 @@ public class LabelFieldForm extends AbstractForm implements IPageForm {
     }
 
     @Order(10)
-    @ClassId("3d01b817-448f-475d-ae4e-e8f8841b96b3")
-    public class ExamplesBox extends AbstractGroupBox {
+    @ClassId("e5590d6c-9784-445a-a10d-83a10defcf6d")
+    public class LabelFieldBox extends AbstractGroupBox {
 
       @Override
       protected String getConfiguredLabel() {
-        return TEXTS.get("Examples");
+        return "Label Field";
       }
 
       @Order(10)
-      @ClassId("e72fd12f-f40c-4f32-9676-ed34b665d694")
+      @ClassId("e1e2e679-a9a2-4d64-8321-2875fe1cea25")
       public class LabelField extends AbstractLabelField {
 
         @Override
         protected String getConfiguredLabel() {
-          return TEXTS.get("Default");
-        }
-      }
-
-      @Order(20)
-      @ClassId("5d127d04-241c-47df-82be-cc8142243311")
-      public class DisabledField extends AbstractLabelField {
-
-        @Override
-        protected boolean getConfiguredEnabled() {
-          return false;
+          return "Message of the Day";
         }
 
         @Override
-        protected String getConfiguredLabel() {
-          return TEXTS.get("Disabled");
-        }
-      }
-
-      @Order(30)
-      @ClassId("51d49100-34d7-45fc-9e29-45379cfdff23")
-      public class StyledField extends AbstractLabelField {
-
-        @Override
-        protected String getConfiguredLabel() {
-          return TEXTS.get("Styled");
-        }
-
-        @Override
-        protected String getConfiguredLabelFont() {
-          return "BOLD-ITALIC";
-        }
-
-        @Override
-        protected String getConfiguredLabelForegroundColor() {
-          return "FF0000";
-        }
-      }
-
-      @Order(40)
-      @ClassId("977b4dce-d3d6-407a-88ae-be5d9a629316")
-      public class HtmlField extends AbstractLabelField {
-
-        @Override
-        protected void execInitField() {
-          setValue(HTML.fragment(
-            "This field contains ",
-            HTML.bold("HTML"),
-            " and supports ",
-            HTML.appLink("foo-ref", "App links")).toHtml());
-        }
-
-        @Override
-        protected boolean getConfiguredHtmlEnabled() {
-          return true;
+        protected byte getConfiguredLabelPosition() {
+          return LABEL_POSITION_TOP;
         }
 
         @Override
@@ -132,102 +113,263 @@ public class LabelFieldForm extends AbstractForm implements IPageForm {
         }
 
         @Override
+        protected boolean getConfiguredGridUseUiHeight() {
+          return true;
+        }
+
+        @Override
+        protected void execInitField() {
+          setValue("Hello World!");
+        }
+
+        @Override
         protected void execAppLinkAction(String ref) {
-          MessageBoxes.createOk().withBody("App link with ref '" + ref + "' clicked").show();
+          MessageBoxes.createOk().withBody("App link was clicked!\n\n[ref=" + ref + "]").show();
+        }
+      }
+    }
+
+    @Order(20)
+    @ClassId("c27818b5-1bee-4020-825a-4ec8ee5fc3f1")
+    public class LabelFieldPropertiesBox extends AbstractGroupBox {
+
+      @Override
+      protected String getConfiguredLabel() {
+        return "Label Field Properties";
+      }
+
+      @Order(10)
+      @ClassId("c69556a4-6a7d-4f20-84b5-b383b6f4a469")
+      public class LabelValueField extends AbstractStringField {
+
+        @Override
+        protected String getConfiguredLabel() {
+          return "Value";
+        }
+
+        @Override
+        protected int getConfiguredGridH() {
+          return 5;
+        }
+
+        @Override
+        protected double getConfiguredGridWeightY() {
+          return 0;
+        }
+
+        @Override
+        protected boolean getConfiguredMultilineText() {
+          return true;
+        }
+
+        @Override
+        protected boolean getConfiguredWrapText() {
+          return true;
+        }
+
+        @Override
+        protected int getConfiguredMaxLength() {
+          return 1024 * 1024; // 1 MB
+        }
+
+        @Override
+        protected void execInitField() {
+          getLabelField().addPropertyChangeListener(ILabelField.PROP_VALUE, event -> setValueWithoutValueChangeTriggers(this, getLabelField().getValue()));
+          setValueWithoutValueChangeTriggers(this, getLabelField().getValue());
+        }
+
+        @Override
+        protected void execChangedValue() {
+          getLabelField().setValue(getValue());
+        }
+      }
+
+      @Order(20)
+      @ClassId("ea901a7c-7907-4ecf-b9df-ed1d34e6887e")
+      public class HtmlEnabledField extends AbstractBooleanField {
+
+        @Override
+        protected String getConfiguredLabel() {
+          return "Html Enabled";
+        }
+
+        @Override
+        protected boolean getConfiguredLabelVisible() {
+          return false;
+        }
+
+        @Override
+        protected void execInitField() {
+          getLabelField().addPropertyChangeListener(ILabelField.PROP_HTML_ENABLED, event -> setValueWithoutValueChangeTriggers(this, getLabelField().isHtmlEnabled()));
+          setValueWithoutValueChangeTriggers(this, getLabelField().isHtmlEnabled());
+        }
+
+        @Override
+        protected void execChangedValue() {
+          getLabelField().setHtmlEnabled(isChecked());
+        }
+      }
+
+      @Order(30)
+      @ClassId("f5a8b59c-2518-45f9-b9f7-4f2662246754")
+      public class WrapTextField extends AbstractBooleanField {
+
+        @Override
+        protected String getConfiguredLabel() {
+          return "Wrap Text";
+        }
+
+        @Override
+        protected boolean getConfiguredLabelVisible() {
+          return false;
+        }
+
+        @Override
+        protected void execInitField() {
+          getLabelField().addPropertyChangeListener(ILabelField.PROP_WRAP_TEXT, event -> setValueWithoutValueChangeTriggers(this, getLabelField().isWrapText()));
+          setValueWithoutValueChangeTriggers(this, getLabelField().isWrapText());
+        }
+
+        @Override
+        protected void execChangedValue() {
+          getLabelField().setWrapText(isChecked());
+        }
+      }
+
+      @Order(40)
+      @ClassId("a92f71d0-af5a-4270-9f05-d8b0078d5cd8")
+      public class SelectableField extends AbstractBooleanField {
+
+        @Override
+        protected String getConfiguredLabel() {
+          return "Selectable";
+        }
+
+        @Override
+        protected boolean getConfiguredLabelVisible() {
+          return false;
+        }
+
+        @Override
+        protected void execInitField() {
+          getLabelField().addPropertyChangeListener(ILabelField.PROP_SELECTABLE, event -> setValueWithoutValueChangeTriggers(this, getLabelField().isSelectable()));
+          setValueWithoutValueChangeTriggers(this, getLabelField().isSelectable());
+        }
+
+        @Override
+        protected void execChangedValue() {
+          getLabelField().setSelectable(isChecked());
         }
       }
     }
 
     @Order(30)
-    @ClassId("b4ad4e83-5395-4874-b918-a644f879b0da")
-    public class ConfigurationBox extends AbstractGroupBox {
+    @ClassId("6c1b1c07-f0ea-4e36-9712-7b678a18a105")
+    public class FormFieldPropertiesBox extends AbstractFormFieldPropertiesBox {
 
       @Override
-      protected String getConfiguredLabel() {
-        return TEXTS.get("Configure");
-      }
-
-      @Order(10)
-      @ClassId("6b495bc0-ccd3-47f6-8656-58ec4dc790f7")
-      public class TooLongLabelTextGetsTruncatedField extends AbstractLabelField {
-
-        @Override
-        protected String getConfiguredLabel() {
-          return TEXTS.get("TooLongLabelTextGetsTruncated");
-        }
-      }
-
-      @Order(20)
-      @ClassId("c3fc696c-f21d-4a0d-9d79-7f05528d7937")
-      public class SetValueTextField extends AbstractLabelField {
-
-        @Override
-        protected String getConfiguredLabel() {
-          return " ";
-        }
-
-        @Override
-        protected void execInitField() {
-          setValue(TEXTS.get("SetValueText"));
-        }
-      }
-
-      @Order(30)
-      @ClassId("c2971b37-22e4-4865-b4c9-5756147aafdd")
-      public class MultilineLabelField extends AbstractLabelField {
-
-        @Override
-        protected boolean getConfiguredGridUseUiHeight() {
-          return true;
-        }
-
-        @Override
-        protected String getConfiguredLabel() {
-          return TEXTS.get("MultilineLabel");
-        }
-
-        @Override
-        protected boolean getConfiguredWrapText() {
-          return true;
-        }
-
-        @Override
-        protected void execInitField() {
-          String value = TEXTS.get("Lorem");
-          this.setValue(value);
-        }
-      }
-
-      @Order(40)
-      @ClassId("18baf59a-713d-4e9f-a09e-432c6f9732d4")
-      public class VeryLongLabelTextField extends AbstractLabelField {
-
-        @Override
-        protected boolean getConfiguredGridUseUiHeight() {
-          return true;
-        }
-
-        @Override
-        protected boolean getConfiguredLabelVisible() {
-          return false;
-        }
-
-        @Override
-        protected boolean getConfiguredWrapText() {
-          return true;
-        }
-
-        @Override
-        protected void execInitField() {
-          String value = TEXTS.get("Lorem");
-          this.setValue(value);
-        }
+      protected void execInitField() {
+        setField(getLabelField());
       }
     }
 
     @Order(40)
     @ClassId("66fe293d-684c-4508-aca6-a0cf9810e79a")
     public class CloseButton extends AbstractCloseButton {
+    }
+
+    @Order(50)
+    @ClassId("11c9067e-4c3f-4fb1-b344-8768c07e6841")
+    public class ExampleValuesMenu extends AbstractButton {
+
+      @Override
+      protected String getConfiguredLabel() {
+        return "Example Values";
+      }
+
+      @Order(10)
+      @ClassId("f700cfa8-0827-4bc9-8abd-6c261f9db3d8")
+      public class ShortTextMenu extends AbstractMenu {
+
+        @Override
+        protected String getConfiguredText() {
+          return "Short Text";
+        }
+
+        @Override
+        protected void execAction() {
+          getLabelField().setValue("Lorem ipsum dolor sit amet.");
+          getLabelField().setWrapText(false);
+          getLabelField().setHtmlEnabled(false);
+        }
+      }
+
+      @Order(20)
+      @ClassId("4266d1cb-b046-45ab-86a8-b5a812125506")
+      public class LongTextMenu extends AbstractMenu {
+
+        @Override
+        protected String getConfiguredText() {
+          return "Long Text";
+        }
+
+        @Override
+        protected void execAction() {
+          getLabelField().setValue("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. " +
+              "\n\n" +
+              "At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. " +
+              "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. " +
+              "At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est.");
+          getLabelField().setWrapText(true);
+          getLabelField().setHtmlEnabled(false);
+        }
+      }
+
+      @Order(30)
+      @ClassId("c0f2d4e9-1d95-48a9-a76d-6f1a4ebea4ca")
+      public class ShortHtmlMenu extends AbstractMenu {
+
+        @Override
+        protected String getConfiguredText() {
+          return "Short HTML";
+        }
+
+        @Override
+        protected void execAction() {
+          getLabelField().setValue(HTML.div(HTML.fragment("Lorem "), HTML.appLink("ipsum", "ipsum"), HTML.fragment(" dolor sit "), HTML.bold("amet.")).toHtml());
+          getLabelField().setWrapText(false);
+          getLabelField().setHtmlEnabled(true);
+        }
+      }
+
+      @Order(40)
+      @ClassId("b2d14867-4496-47d7-b7fa-f473999a541f")
+      public class LongHtmlMenu extends AbstractMenu {
+
+        @Override
+        protected String getConfiguredText() {
+          return "Long HTML";
+        }
+
+        @Override
+        protected void execAction() {
+          getLabelField().setValue(HTML.div(
+              HTML.fragment("Lorem "),
+              HTML.appLink("ipsum", "ipsum"),
+              HTML.fragment(" dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua."),
+              HTML.br(),
+              HTML.br(),
+              HTML.fragment("At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum "),
+              HTML.appLink("dolor", "dolor"),
+              HTML.fragment(" sit amet. "),
+              HTML.appLink("lorem", "Lorem"),
+              HTML.fragment(" ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. " +
+                  "At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est."))
+              .toHtml());
+          getLabelField().setWrapText(true);
+          getLabelField().setHtmlEnabled(true);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Use a single, configurable field
- Provide nicer example values (both plaintext and HTML)
- Use AbstractFormFieldPropertiesBox to set common properties

HtmlFieldForm: add checkbox for new "selectable" property.

280491