### PR TITLE
Fixed isEditable and removable behavior of checkable columns

### DIFF
--- a/docs/adoc/migration/MigrationGuide_22_0.adoc
+++ b/docs/adoc/migration/MigrationGuide_22_0.adoc
@@ -572,4 +572,7 @@ For more information about the filter API and the filter field see link:{techdoc
 
 == Checkable Columns
 
-Boolean columns that are marked as `AbstractTable#getConfiguredCheckableColumn()` do not support `execPrepareEdit` and `execCompleteEdit` anymore. Existing logic should be migrated to `AbstractTable#execRowsChecked(rows)`.
+Boolean columns that are marked as `AbstractTable#getConfiguredCheckableColumn()` now support to be set to editable=false (see `AbstractColumn#getConfiguredEditable()` for more details).
+This is relevant for checkable columns that have been set to editable=false without any effect until now. It should be verified whether the new behavior is still as expected for such cases.
+
+As a consequence, checkable columns do not support `execPrepareEdit` and `execCompleteEdit` anymore. Existing logic should be migrated to `AbstractTable#execRowsChecked(rows)`.

--- a/docs/adoc/migration/MigrationGuide_22_0.adoc
+++ b/docs/adoc/migration/MigrationGuide_22_0.adoc
@@ -569,3 +569,7 @@ These widgets support a text filter that is shown while typing if the widget is 
 Fields that provide this functionality may now be obsolete and can be removed.
 
 For more information about the filter API and the filter field see link:{techdocjs}#filter-field[Technical Guide for Scout JS].
+
+== Checkable Columns
+
+Boolean columns that are marked as `AbstractTable#getConfiguredCheckableColumn()` do not support `execPrepareEdit` and `execCompleteEdit` anymore. Existing logic should be migrated to `AbstractTable#execRowsChecked(rows)`.


### PR DESCRIPTION
- Checkable columns can now be set to isEditable=false
- Checkable columns cannot be removed through the UI anymore