### PR TITLE
Popup: add modal behaviour

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/popup/PopupForm.js
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/popup/PopupForm.js
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2017 BSI Business Systems Integration AG.
+ * Copyright (c) 2022 BSI Business Systems Integration AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/org/documents/edl-v10.html
+ * https://www.eclipse.org/org/documents/edl-v10.html
  *
  * Contributors:
  *     BSI Business Systems Integration AG - initial API and implementation
@@ -36,6 +36,9 @@ export default class PopupForm extends Form {
 
     let anchorBoundsField = this.widget('AnchorBoundsField');
     anchorBoundsField.on('propertyChange', this._onAnchorBoundsChange.bind(this));
+
+    let modalField = this.widget('ModalField');
+    modalField.setValue(dummyPopup.modal);
 
     let closeOnAnchorMouseDownField = this.widget('CloseOnAnchorMouseDownField');
     closeOnAnchorMouseDownField.setValue(dummyPopup.closeOnAnchorMouseDown);
@@ -102,6 +105,7 @@ export default class PopupForm extends Form {
       parent: this,
       $anchor: $anchor,
       anchorBounds: anchorBounds,
+      modal: this.widget('ModalField').value,
       closeOnAnchorMouseDown: this.widget('CloseOnAnchorMouseDownField').value,
       closeOnMouseDownOutside: this.widget('CloseOnMouseDownOutsideField').value,
       closeOnOtherPopupOpen: this.widget('CloseOnOtherPopupOpenField').value,

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/popup/PopupFormModel.js
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/popup/PopupFormModel.js
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2022 BSI Business Systems Integration AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ *     BSI Business Systems Integration AG - initial API and implementation
+ */
 export default () => ({
   id: 'jswidgets.PopupForm',
   displayHint: 'view',
@@ -57,6 +67,13 @@ export default () => ({
                     objectType: 'StringField',
                     label: 'Anchor Bounds',
                     tooltipText: '${textKey:AnchorBoundsTooltip}'
+                  },
+                  {
+                    id: 'ModalField',
+                    objectType: 'CheckBoxField',
+                    label: 'Modal',
+                    tooltipText: 'If set, the following properties are overruled: "closeOnAnchorMouseDown", "closeOnMouseDownOutside", "closeOnOtherPopupOpen" and "withGlassPane".',
+                    labelVisible: false
                   },
                   {
                     id: 'CloseOnAnchorMouseDownField',


### PR DESCRIPTION
The popup has now a new property "modal", which adds a glass pane and prevents any closing from mouse down (on anchor or outside) or other popups.

331648