### PR TITLE
One Day Tutorial: Remove code parts using ContactsHelper class

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/organization/OrganizationForm.java
+++ b/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/organization/OrganizationForm.java
@@ -154,24 +154,27 @@ public class OrganizationForm extends AbstractForm {
   public PhoneField getPhoneField() {
     return getFieldByClass(PhoneField.class);
   }
-  // tag::layout[]
-
 
   @Override
   protected void execInitForm() {
     BEANS.get(ContactsHelper.class).handleReadOnly(getOkButton());
   }
 
+  // tag::layout[]
   // tag::refactor[]
   @Order(10)
   @ClassId("e7efc084-fe7a-462f-ba23-914e58f7b82d")
   public class MainBox extends AbstractGroupBox {
+    // end::refactor[]
+    // end::layout[]
 
     @Override
     protected void injectMenusInternal(OrderedCollection<IMenu> menus) {
       BEANS.get(ContactsHelper.class).injectReadOnlyMenu(menus);
     }
 
+    // tag::layout[]
+    // tag::refactor[]
     @Order(10)
     @ClassId("b20aad47-e070-4f3c-bafc-ddbaa3ae2a4c")
     public class GeneralBox extends AbstractGroupBox {


### PR DESCRIPTION
In the tutorial, the `ContactsHelper` class is not used (in contrast to the Contacts Demo application).
Therefore, all code parts using that class should be removed from the excerpts used in the tutorial so that all code shown in the tutorial is valid for the tutorial project.