### PR TITLE
Update npm dependencies to non-snapshot variant

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.ui.html/package.json
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html/package.json
@@ -37,11 +37,11 @@
     "version:release": "releng-scripts version:release"
   },
   "devDependencies": {
-    "@eclipse-scout/cli": ">=22.0.0-snapshot <22.0.0",
+    "@eclipse-scout/cli": "^22.0.0",
     "@eclipse-scout/releng": "^22.0.0"
   },
   "dependencies": {
-    "@eclipse-scout/core": ">=22.0.0-snapshot <22.0.0",
+    "@eclipse-scout/core": "^22.0.0",
     "jquery": "3.6.0"
   }
 }


### PR DESCRIPTION
Currently, it is not possible for external people to run the Contacts demo application locally on their own device because the JavaScript part depends on the `snapshot` builds which are only available on our internal package registry.

This PR adjusts these dependencies to the ordinary releases of those packages which are available through the public npm registry.

_An alternative approach would be to bring back the snapshot builds to the public npm registry._