### PR TITLE
Disable automatic LogbackServletContainerInitializer

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.all.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/code/contacts/org.eclipse.scout.contacts.all.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -69,4 +69,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/contacts/org.eclipse.scout.contacts.server.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/code/contacts/org.eclipse.scout.contacts.server.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -69,4 +69,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/contacts/org.eclipse.scout.contacts.server.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/code/contacts/org.eclipse.scout.contacts.server.app.war/src/main/webapp/WEB-INF/web.xml
@@ -68,4 +68,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/contacts/org.eclipse.scout.contacts.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -69,4 +69,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/contacts/org.eclipse.scout.contacts.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
@@ -69,4 +69,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -71,4 +71,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
@@ -71,4 +71,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app.dev/src/main/webapp/WEB-INF/web.xml
@@ -69,4 +69,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app.selenium/src/main/webapp/WEB-INF/web.xml
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app.selenium/src/main/webapp/WEB-INF/web.xml
@@ -55,4 +55,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app.war/src/main/webapp/WEB-INF/web.xml
@@ -69,4 +69,9 @@
     </cookie-config>
   </session-config>
 
+  <context-param>
+    <param-name>logbackDisableServletContainerInitializer</param-name>
+    <param-value>true</param-value>
+  </context-param>
+
 </web-app>


### PR DESCRIPTION
Logback provides an automatic LogbackServletContainerInitializer which registers LogbackServletContextListener to stop logback during web application context stop. However this listener may be run to early as we cannot control at what time during context stop this listener is run, this may lead to logging messages which are not logged anymore.

Solution: Stop logback a little bit later during context stop using a platform listener and disable LogbackServletContainerInitializer.

LogbackServletContainerInitializer may be disabled by adding

<context-param>
 <param-name>logbackDisableServletContainerInitializer</param-name>
 <param-value>true</param-value>
</context-param>

in the web.xml; the new LoggerShutdownPlatformListener is automatically run during platform stop as late as possible (using a high order).

331773