### PR TITLE
add defaultMenuTypes

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTableModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTableModel.ts
@@ -68,18 +68,12 @@ export default (): PageModel => ({
         id: 'AddRowMenu',
         objectType: Menu,
         text: '${textKey:AddRow}',
-        menuTypes: [
-          Table.MenuTypes.EmptySpace
-        ],
         keyStroke: 'insert'
       },
       {
         id: 'AddManyMenu',
         objectType: Menu,
-        text: 'Add many',
-        menuTypes: [
-          Table.MenuTypes.EmptySpace
-        ]
+        text: 'Add many'
       },
       {
         id: 'DeleteRowMenu',
@@ -96,10 +90,7 @@ export default (): PageModel => ({
         objectType: Menu,
         iconId: icons.SQUARE_BOLD,
         stackable: false,
-        horizontalAlignment: 1,
-        menuTypes: [
-          Table.MenuTypes.EmptySpace
-        ]
+        horizontalAlignment: 1
       }
     ],
     tableControls: [

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
@@ -93,9 +93,6 @@ export default (): FormModel => ({
                   id: 'AddRowMenu',
                   objectType: Menu,
                   text: '${textKey:AddRow}',
-                  menuTypes: [
-                    Table.MenuTypes.EmptySpace
-                  ],
                   keyStroke: 'insert'
                 },
                 {

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTableFormModel.ts
@@ -73,25 +73,21 @@ export default (): FormModel => ({
                   id: 'ContentMenu',
                   objectType: Menu,
                   text: 'Content',
-                  menuTypes: [Table.MenuTypes.EmptySpace],
                   childActions: [
                     {
                       id: 'RemoveAll',
                       objectType: Menu,
-                      text: 'Remove all rows',
-                      menuTypes: [Table.MenuTypes.EmptySpace]
+                      text: 'Remove all rows'
                     },
                     {
                       id: 'InsertFew',
                       objectType: Menu,
-                      text: 'Insert few',
-                      menuTypes: [Table.MenuTypes.EmptySpace]
+                      text: 'Insert few'
                     },
                     {
                       id: 'InsertMany',
                       objectType: Menu,
-                      text: 'Insert many',
-                      menuTypes: [Table.MenuTypes.EmptySpace]
+                      text: 'Insert many'
                     }
                   ]
                 },
@@ -99,7 +95,6 @@ export default (): FormModel => ({
                   id: 'AddRowMenu',
                   objectType: Menu,
                   text: '${textKey:AddRow}',
-                  menuTypes: [Table.MenuTypes.EmptySpace],
                   keyStroke: 'insert'
                 },
                 {

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tree/TreeFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tree/TreeFormModel.ts
@@ -41,18 +41,12 @@ export default (): FormModel => ({
                   id: 'AddNodeMenu',
                   objectType: Menu,
                   text: '${textKey:AddNode}',
-                  menuTypes: [
-                    Tree.MenuTypes.EmptySpace
-                  ],
                   keyStroke: 'insert'
                 },
                 {
                   id: 'AddChildNodeMenu',
                   objectType: Menu,
                   text: '${textKey:AddChildNode}',
-                  menuTypes: [
-                    Tree.MenuTypes.EmptySpace
-                  ],
                   keyStroke: 'insert'
                 },
                 {
@@ -69,25 +63,16 @@ export default (): FormModel => ({
                   id: 'DeleteAllMenu',
                   objectType: Menu,
                   text: '${textKey:DeleteAll}',
-                  menuTypes: [
-                    Tree.MenuTypes.EmptySpace
-                  ],
                   childActions: [
                     {
                       id: 'DeleteAllNodesMenu',
                       objectType: Menu,
-                      text: '${textKey:DeleteAllNodes}',
-                      menuTypes: [
-                        Tree.MenuTypes.EmptySpace
-                      ]
+                      text: '${textKey:DeleteAllNodes}'
                     },
                     {
                       id: 'DeleteAllChildNodesMenu',
                       objectType: Menu,
-                      text: '${textKey:DeleteAllChildNodes}',
-                      menuTypes: [
-                        Tree.MenuTypes.EmptySpace
-                      ]
+                      text: '${textKey:DeleteAllChildNodes}'
                     }
                   ]
                 }

--- a/docs/adoc/releasenotes/ReleaseNotes_23_1.adoc
+++ b/docs/adoc/releasenotes/ReleaseNotes_23_1.adoc
@@ -252,6 +252,12 @@ Menu type support has been added to the `ValueField` and the `ImageField`.
 This means that e.g. the `ValueField` will display different menus whether a value is set or not.
 For more information about the menuType support of `ValueField` and `ImageField` see link:{techdocjs}#menu-types[Technical Guide for Scout JS].
 
+==== Default menuTypes
+
+Default menuTypes have been added to several widgets.
+This means that e.g. the `Table` treats a menu without a menuType as if it had set `Table.MenuTypes.EmptySpace`.
+For more information about the default menuTypes see link:{techdocjs}#menu-types[Technical Guide for Scout JS].
+
 == JavaScript Code Migration Tool
 
 It is normal that code changes from time to time even on a larger scale.

--- a/docs/adoc/technicalGuideJS/ScoutJS.adoc
+++ b/docs/adoc/technicalGuideJS/ScoutJS.adoc
@@ -1420,6 +1420,25 @@ Menu types are context specific and interpreted by the menu container (e.g. by a
 
 Please refer to the respective container for the available menu types and their functions.
 
+Most widgets specify some default menuTypes. Menus without any menuTypes are treated as if these default menuTypes are set. The defaults are:
+
+* `Calendar`
+** `Calendar.MenuTypes.EmptySpace`
+* `ImageField`
+** `ImageField.MenuTypes.ImageUrl`
+** `ImageField.MenuTypes.Null`
+* `Planner`
+** `Planner.MenuTypes.EmptySpace`
+* `Table`
+** `Table.MenuTypes.EmptySpace`
+* `TileGrid`
+** `TileGrid.MenuTypes.EmptySpace`
+* `Tree`
+** `Tree.MenuTypes.EmptySpace`
+* `ValueField`
+** `ValueField.MenuTypes.NotNull`
+** `ValueField.MenuTypes.Null`
+
 ==== ValueField
 
 The `ValueField` support the menu types `ValueField.MenuTypes.Null` and `ValueField.MenuTypes.NotNull`.


### PR DESCRIPTION
Add defaultMenuTypes to Calendar, Planner, Table, TileGrid and Tree. A
menu without menuTypes will be treated as EmptySpace-menu.

326261