### PR TITLE
Use scout-version attribute

### DIFF
--- a/docs/adoc/sdk/SdkEclipseInstallation.adoc
+++ b/docs/adoc/sdk/SdkEclipseInstallation.adoc
@@ -26,7 +26,7 @@ There are two ways to install it.
 
 === Install Eclipse IDE for Scout Developers
 
-The installation process for the Eclipse package containing Scout is described in the http://eclipsescout.github.io/{scout-short-version}/helloscout.html#Eclipse[Hello Scout Tutorial].
+The installation process for the Eclipse package containing Scout is described in the http://eclipsescout.github.io/{scout-version}/helloscout.html#Eclipse[Hello Scout Tutorial].
 
 === Add Scout to your Existing Eclipse IDE
 
@@ -55,4 +55,4 @@ After the restart of the Eclipse IDE the Scout SDK is ready to use!
 === Verifying the Installation
 
 The simplest way to verify your Scout installation is to create a "`Hello World`" Scout project
-and run the corresponding Scout application as described in http://eclipsescout.github.io/{scout-short-version}/helloscout.html[Hello Scout].
+and run the corresponding Scout application as described in http://eclipsescout.github.io/{scout-version}/helloscout.html[Hello Scout].


### PR DESCRIPTION
The scout-short-version attribute does not exist. The file includes _initDoc.adoc, however:

ifndef::finaldoc[]
include::../_initDoc.adoc[]
endif::finaldoc[]

There, scout-version is defined:

:scout-version: 11.0

And that's the version we need, as shown in this merge request:
https://github.com/eclipsescout/eclipsescout.github.io/pull/6/files