### PR TITLE
Config Properties go into a definition list

### DIFF
--- a/docs/modules/technical-guide/pages/common-concepts/platform.adoc
+++ b/docs/modules/technical-guide/pages/common-concepts/platform.adoc
@@ -373,615 +373,726 @@ To minimize configuration files such entries should be removed from `config.prop
 [[sec-app.configProperties]]
 == Scout Config Properties
 
-[cols="2,4,1,1", options="header"]
-.Config Properties
-|===
-|Key
-|Description
-|Data Type
-|Kind
-|`scout.application.name`
-|The display name of the application. Used e.g. in the info form and the diagnostic views. The default value is `unknown`.
-|String
-|Config Property
-|`scout.application.version`
-|The application version as displayed to the user. Used e.g. in the info form and the diagnostic views. The default value is `0.0.0`.
-|String
-|Config Property
-|`scout.auth.anonymousEnabled`
-|Specifies if the `AnonymousAccessController` is enabled. Therefore, if a security filter uses this controller no login is required.
-|Boolean
-|Config Property
-|`scout.auth.cookieEnabled`
-|Specifies if the `CookieAccessController` is enabled.
-|Boolean
-|Config Property
-|`scout.auth.cookieMaxAge`
-|If the `CookieAccessController` is enabled, specifies the maximum age in seconds for the cookie.
+`scout.application.name` ::
+The display name of the application. Used e.g. in the info form and the diagnostic views. The default value is `unknown`.
++
+Data type: String
 
+`scout.application.version` ::
+The application version as displayed to the user. Used e.g. in the info form and the diagnostic views. The default value is `0.0.0`.
++
+Data type: String
+
+`scout.auth.anonymousEnabled` ::
+Specifies if the `AnonymousAccessController` is enabled. Therefore, if a security filter uses this controller no login is required.
++
+Data type: Boolean
+
+`scout.auth.cookieEnabled` ::
+Specifies if the `CookieAccessController` is enabled.
++
+Data type: Boolean
+
+`scout.auth.cookieMaxAge` ::
+If the `CookieAccessController` is enabled, specifies the maximum age in seconds for the cookie.
++
 A positive value indicates that the cookie will expire after that many seconds have passed.
-
++
 A negative value means that the cookie is not stored persistently and will be deleted when the Web browser exits. A zero value causes the cookie to be deleted.
-
++
 The default value is 10 hours.
-|Long
-|Config Property
-|`scout.auth.cookieName`
-|If the `CookieAccessController` is enabled, specifies the name for the cookie.
++
+Data type: Long
 
+`scout.auth.cookieName` ::
+If the `CookieAccessController` is enabled, specifies the name for the cookie.
++
 The name must conform to RFC 2109. However, vendors may provide a configuration option that allows cookie names conforming to the original Netscape Cookie Specification to be accepted.
-
++
 By default `sso.user.id` is used as cookie name.
-|String
-|Config Property
-|`scout.auth.cookieSessionValidateSecure`
-|Specifies if the UI server should ensure a secure cookie configuration of the webapp.
++
+Data type: String
 
+`scout.auth.cookieSessionValidateSecure` ::
+Specifies if the UI server should ensure a secure cookie configuration of the webapp.
++
 If enabled the application validates that the `httpOnly` and `Secure` flags are set in the cookie configuration in the web.xml.
-
++
 This property should be disabled if no secure connection (https) is used to the client browser (not recommended).
-
++
 The default value is true.
-|Boolean
-|Config Property
-|`scout.auth.credentials`
-|Specifies the known credentials (username & passwords) of the `org.eclipse.scout.rt.platform.security.ConfigFileCredentialVerifier`.
++
+Data type: Boolean
 
+`scout.auth.credentials` ::
+Specifies the known credentials (username & passwords) of the `org.eclipse.scout.rt.platform.security.ConfigFileCredentialVerifier`.
++
 Credentials are separated by semicolon. Username and password information are separated by colon. Usernames are case-insensitive, and it is recommended that they should only consist of ASCII characters. Plain text passwords are case-sensitive.
-
++
 By default the password information consists of Base64 encoded salt followed by a dot followed by the Base64 encoded SHA-512 hash of the password (using UTF-16).
-
-Example: username1:base64EncodedSalt.base64EncodedPasswordHash;username2:base64EncodedSalt.base64EncodedPasswordHash
-
++
+Example:
++
+[listing]
+scout.auth.credentials=username1:base64EncodedSalt.base64EncodedPasswordHash;username2:base64EncodedSalt.base64EncodedPasswordHash
++
 To create a salt and hash tuples based on a clear text password use the `org.eclipse.scout.rt.platform.security.ConfigFileCredentialVerifier.main()` method that can be invoked from the command line.
-
++
 If `scout.auth.credentialsPlaintext` is set to `true` the password information just consists of the cleartext password.
-|String
-|Config Property
-|`scout.auth.credentialsPlaintext`
-|Specifies if the passwords specified in property `scout.auth.credentials` is plaintext (not recommended) or hashed. A value of false indicates hashed passwords which is the default.
-|Boolean
-|Config Property
-|`scout.auth.privateKey`
-|Specifies the Base64 encoded private key for signing requests from the UI server to the backend server. By validating the signature the server can ensure the request is trustworthy.
++
+Data type: String
 
+`scout.auth.credentialsPlaintext` ::
+Specifies if the passwords specified in property `scout.auth.credentials` is plaintext (not recommended) or hashed. A value of false indicates hashed passwords which is the default.
++
+Data type: Boolean
+
+`scout.auth.privateKey` ::
+Specifies the Base64 encoded private key for signing requests from the UI server to the backend server. By validating the signature the server can ensure the request is trustworthy.
++
 Furthermore, the CookieAccessController uses this private key to sign the cookie.
-
++
 New public-private-key-pairs can be created by invoking the class `org.eclipse.scout.rt.platform.security.SecurityUtility` on the command line.
-|Base64 encoded String
-|Config Property
-|`scout.auth.publicKey`
-|Specifies the Base64 encoded public key used to validate signed requests on the backend server. The public key must match the private key stored in the property `scout.auth.privateKey` on the UI server.
++
+Data type: Base64 encoded String
 
+`scout.auth.publicKey` ::
+Specifies the Base64 encoded public key used to validate signed requests on the backend server. The public key must match the private key stored in the property `scout.auth.privateKey` on the UI server.
++
 New public-private-key-pairs can be created by invoking the class `org.eclipse.scout.rt.platform.security.SecurityUtility` on the command line.
-|Base64 encoded String
-|Config Property
-|`scout.auth.tokenTtl`
-|Number of milliseconds a signature on a request from the UI server to the backend server is valid (TTL for the authentication token). If a request is not received within this time, it is rejected.
++
+Data type: Base64 encoded String
 
+`scout.auth.tokenTtl` ::
+Number of milliseconds a signature on a request from the UI server to the backend server is valid (TTL for the authentication token). If a request is not received within this time, it is rejected.
++
 By default this property is set to 10 minutes.
-|Long >= 0
-|Config Property
-|`scout.backendUrl`
-|The URL of the scout backend server (without any servlets). E.g.: http://localhost:8080
++
+Data type: Long >= 0
 
+`scout.backendUrl` ::
+The URL of the scout backend server (without any servlets).
++
+Example:
++
+[listing]
+scout.backendUrl=http://localhost:8080
++
 By default this property is null.
-|String
-|Config Property
-|`scout.client.jobCompletionDelayOnSessionShutdown`
-|Specifies the maximal time (in seconds) to wait until running jobs are cancelled on session shutdown.
++
+Data type: String
 
+`scout.client.jobCompletionDelayOnSessionShutdown` ::
+Specifies the maximal time (in seconds) to wait until running jobs are cancelled on session shutdown.
++
 The default value is 10 seconds.
-|Long >= 0
-|Config Property
-|`scout.client.memoryPolicy`
-|Specifies how long the client keeps fetched data before it is discarded. One of `small`, `medium` or `large`. The default value is `large`.
-|String
-|Config Property
-|`scout.client.notificationSubject`
-|Technical subject under which received client notifications are executed.
++
+Data type: Long >= 0
 
+`scout.client.memoryPolicy` ::
+Specifies how long the client keeps fetched data before it is discarded. One of `small`, `medium` or `large`. The default value is `large`.
++
+Data type: String
+
+`scout.client.notificationSubject` ::
+Technical subject under which received client notifications are executed.
++
 By default `notification-authenticator` is used.
-|Subject name as String
-|Config Property
-|`scout.client.testingSessionTtl`
-|Testing client session expiration in milliseconds. The default value is 1 day.
-|Long >= 0
-|Config Property
-|`scout.client.userArea`
-|User data area (e.g. in the user home) to store user preferences. If nothing is specified the user home of the operating system is used. By default no user home is set.
-|String
-|Config Property
-|`scout.clientnotification.chunkSize`
-|The maximum number of client notifications that are consumed at once. The default is 30.
-|Integer >= 0
-|Config Property
-|`scout.clientnotification.maxNotificationBlockingTimeOut`
-|The maximum amount of time in millisecons a consumer blocks while waiting for new notifications. The default is 10 seconds.
-|Integer >= 0
-|Config Property
-|`scout.clientnotification.nodeQueueCapacity`
-|Capacity of the client notification queue. If maximum capacity is reached, notification messages are dropped. The default value is 200.
-|Integer >= 0
-|Config Property
-|`scout.clientnotification.notificationQueueExpireTime`
-|If no message is consumed for the specified number of milliseconds, client notification queues (with possibly pending notifications) are removed.
++
+Data type: Subject name as String
 
+`scout.client.testingSessionTtl` ::
+Testing client session expiration in milliseconds. The default value is 1 day.
++
+Data type: Long >= 0
+
+`scout.client.userArea` ::
+User data area (e.g. in the user home) to store user preferences. If nothing is specified the user home of the operating system is used. By default no user home is set.
++
+Data type: String
+
+`scout.clientnotification.chunkSize` ::
+The maximum number of client notifications that are consumed at once. The default is 30.
++
+Data type: Integer >= 0
+
+`scout.clientnotification.maxNotificationBlockingTimeOut` ::
+The maximum amount of time in millisecons a consumer blocks while waiting for new notifications. The default is 10 seconds.
++
+Data type: Integer >= 0
+
+`scout.clientnotification.nodeQueueCapacity` ::
+Capacity of the client notification queue. If maximum capacity is reached, notification messages are dropped. The default value is 200.
++
+Data type: Integer >= 0
+
+`scout.clientnotification.notificationQueueExpireTime` ::
+If no message is consumed for the specified number of milliseconds, client notification queues (with possibly pending notifications) are removed.
++
 This avoids overflows and unnecessary memory consumption. Old queues may exist if a node does not properly unregister (e.g. due to a crash).
-
++
 The default value is 10 minutes.
-|Integer >= 0
-|Config Property
-|`scout.clustersync.user`
-|Technical subject under which received cluster sync notifications are executed. The default value is `system`.
-|String
-|Config Property
-|`scout.createTunnelToServerBeans`
-|Specifies if the Scout platform should create proxy beans for interfaces annotated with `TunnelToServer`. Calls to beans of such types are then tunneled to the Scout backend.
++
+Data type: Integer >= 0
 
+`scout.clustersync.user` ::
+Technical subject under which received cluster sync notifications are executed. The default value is `system`.
++
+Data type: String
+
+`scout.createTunnelToServerBeans` ::
+Specifies if the Scout platform should create proxy beans for interfaces annotated with `TunnelToServer`. Calls to beans of such types are then tunneled to the Scout backend.
++
 By default this property is enabled if the property `scout.servicetunnel.targetUrl` is set.
-|Boolean
-|Config Property
-|`scout.cspDirective`
-|Configures individual Content Security Policy (CSP) directives.
++
+Data type: Boolean
 
-See https://www.w3.org/TR/CSP2/ and the Bean `org.eclipse.scout.rt.server.commons.servlet.ContentSecurityPolicy` for more details.
-
+`scout.cspDirective` ::
+Configures individual Content Security Policy (CSP) directives.
++
+See https://www.w3.org/TR/CSP2/[Content Security Policy Level 2] and the Bean `org.eclipse.scout.rt.server.commons.servlet.ContentSecurityPolicy` for more details.
++
 The value must be provided as a Map.
++
+Example:
++
+[listing]
+scout.cspDirective[img-src]=`self` data: https: http://localhost:8086
++
+Data type: Map
 
-Example: scout.cspDirective[img-src]=`self` data: https: http://localhost:8086
-|Map
-|Config Property
-|`scout.cspEnabled`
-|Enable or disable Content Security Policy (CSP) headers. The headers can be modified by replacing the bean `org.eclipse.scout.rt.server.commons.servlet.ContentSecurityPolicy` or using the property `scout.cspDirective`.
-|Boolean
-|Config Property
-|`scout.cspExclusions`
-|A list of regex strings. If the pathInfo of the request matches one of these strings the csp headers won`t be set. This property only has an effect if csp is enabled, see `scout.cspEnabled`.
-|List
-|Config Property
-|`scout.devMode`
-|Property to specify if the application is running in development mode. Default is false.
-|Boolean
-|Config Property
-|`scout.externalBaseUrl`
-|Absolute URL to the deployed http(s):// base of the web-application. The URL should include proxies, redirects, etc.
+`scout.cspEnabled` ::
+Enable or disable Content Security Policy (CSP) headers. The headers can be modified by replacing the bean `org.eclipse.scout.rt.server.commons.servlet.ContentSecurityPolicy` or using the property `scout.cspDirective`.
++
+Data type: Boolean
 
-Example: https://www.my-company.com/my-scout-application/.
+`scout.cspExclusions` ::
+A list of regex strings. If the pathInfo of the request matches one of these strings the csp headers won`t be set. This property only has an effect if csp is enabled, see `scout.cspEnabled`.
++
+Data type: List
 
+`scout.devMode` ::
+Property to specify if the application is running in development mode. Default is false.
++
+Data type: Boolean
+
+`scout.externalBaseUrl` ::
+Absolute URL to the deployed http(s):// base of the web-application. The URL should include proxies, redirects, etc.
++
+Example:
++
+[listing]
+scout.externalBaseUrl=https://www.my-company.com/my-scout-application/.
++
 This URL is used to replace `<scout:base />` tags.
-|String
-|Config Property
-|`scout.healthCheckRemoteUrls`
-|Comma separated list of URLs the `RemoteHealthChecker` should access.
++
+Data type: String
 
+`scout.healthCheckRemoteUrls` ::
+Comma separated list of URLs the `RemoteHealthChecker` should access.
++
 By default no URLs are set.
-|List
-|Config Property
-|`scout.http.connectionTtl`
-|Specifies the maximum life time in milliseconds for kept alive connections of the Apache HTTP client. The default value is 1 hour.
-|Integer
-|Config Property
-|`scout.http.ignoreProxyPatterns`
-|Configure the proxy ignore list for the ConfigurableProxySelector. If an URI matches the pattern no proxy connection is used.
++
+Data type: List
 
+`scout.http.connectionTtl` ::
+Specifies the maximum life time in milliseconds for kept alive connections of the Apache HTTP client. The default value is 1 hour.
++
+Data type: Integer
+
+`scout.http.ignoreProxyPatterns` ::
+Configure the proxy ignore list for the ConfigurableProxySelector. If an URI matches the pattern no proxy connection is used.
++
 By default no proxy is configured.
-
++
 Example:
-
++
+[listing]
 scout.http.ignoreProxyPatterns[0]=https?://localhost(?::\d+)?(?:/.*)?
-
 scout.http.ignoreProxyPatterns[1]=...
-|List
-|Config Property
-|`scout.http.keepAlive`
-|Enable/disable HTTP keep-alive connections.
++
+Data type: List
 
+`scout.http.keepAlive` ::
+Enable/disable HTTP keep-alive connections.
++
 The default value is defined by the system property `http.keepAlive` or true if the system property is undefined.
-|Boolean
-|Config Property
-|`scout.http.maxConnectionsPerRoute`
-|Configuration property to define the default maximum connections per route of the Apache HTTP client. The default value is 32.
-|Integer
-|Config Property
-|`scout.http.maxConnectionsTotal`
-|Specifies the total maximum connections of the Apache HTTP client. The default value is 128.
-|Integer
-|Config Property
-|`scout.http.proxyPatterns`
-|Configure proxies for the `ConfigurableProxySelector`. If an URI matches a pattern the corresponding proxy will be used.
++
+Data type: Boolean
 
+`scout.http.maxConnectionsPerRoute` ::
+Configuration property to define the default maximum connections per route of the Apache HTTP client. The default value is 32.
++
+Data type: Integer
+
+`scout.http.maxConnectionsTotal` ::
+Specifies the total maximum connections of the Apache HTTP client. The default value is 128.
++
+Data type: Integer
+
+`scout.http.proxyPatterns` ::
+Configure proxies for the `ConfigurableProxySelector`. If an URI matches a pattern the corresponding proxy will be used.
++
 By default no proxy is used.
-
++
 The property value is of the format REGEXP_FOR_URI=PROXY_HOST:PROXY_PORT
-
++
 Example:
-
++
+[listing]
 scout.http.proxyPatterns[0]=.*\.example.com(:\d+)?=127.0.0.1:8888
-
 scout.http.proxyPatterns[1]=.*\.example.org(:\d+)?=proxy.company.com
-|List
-|Config Property
-|`scout.http.redirectPost`
-|Enable redirect of POST requests (includes non-idempotent requests). The default value is true
-|Boolean
-|Config Property
-|`scout.http.retryOnNoHttpResponseException`
-|Enable retry of request (includes non-idempotent requests) on NoHttpResponseException
++
+Data type: List
 
+`scout.http.redirectPost` ::
+Enable redirect of POST requests (includes non-idempotent requests). The default value is true
++
+Data type: Boolean
+
+`scout.http.retryOnNoHttpResponseException` ::
+Enable retry of request (includes non-idempotent requests) on NoHttpResponseException
++
 Assuming that the cause of the exception was most probably a stale socket channel on the server side.
-
-For apache tomcat see http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html#d5e659
-
++
 The default value is true
-|Boolean
-|Config Property
-|`scout.http.retryOnSocketExceptionByConnectionReset`
-|Enable retry of request (includes non-idempotent requests) on {@link SocketException} with message `Connection reset`
++
+Data type: Boolean
 
+`scout.http.retryOnSocketExceptionByConnectionReset` ::
+Enable retry of request (includes non-idempotent requests) on {@link SocketException} with message `Connection reset`
++
 Assuming that the cause of the exception was most probably a stale socket channel on the server side.
-
-For apache tomcat see http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html#d5e659
-
++
 The default value is true
-|Boolean
-|Config Property
-|`scout.http.transportFactory`
-|Fully qualified class name of the HTTP transport factory the application uses. The class must implement `org.eclipse.scout.rt.shared.http.IHttpTransportFactory`.
++
+Data type: Boolean
 
+`scout.http.transportFactory` ::
+Fully qualified class name of the HTTP transport factory the application uses. The class must implement `org.eclipse.scout.rt.shared.http.IHttpTransportFactory`.
++
 By default `org.eclipse.scout.rt.shared.http.ApacheHttpTransportFactory` is used.
-|Fully qualified class name. The class must have `org.eclipse.scout.rt.shared.http.IHttpTransportFactory` in its super hierarchy.
-|Config Property
-|`scout.jandex.rebuild`
-|Specifies if Jandex indexes should be rebuilt. Is only necessary to enable during development when the class files change often. The default value is false.
-|RebuildStrategy
-|Config Property
-|`scout.jaxws.consumer.connectTimeout`
-|Connect timeout in milliseconds to abort a webservice request, if establishment of the connection takes longer than this timeout. A timeout of null means an infinite timeout. The default value is null.
-|Integer >= 0
-|Config Property
-|`scout.jaxws.consumer.portCache.corePoolSize`
-|Number of ports to be preemptively cached to speed up webservice calls. The default value is 10.
-|Integer >= 0
-|Config Property
-|`scout.jaxws.consumer.portCache.enabled`
-|Indicates whether to use a preemptive port cache for webservice clients.
++
+Data type: Fully qualified class name. The class must have `org.eclipse.scout.rt.shared.http.IHttpTransportFactory` in its super hierarchy.
 
+`scout.jandex.rebuild` ::
+Specifies if Jandex indexes should be rebuilt. Is only necessary to enable during development when the class files change often. The default value is false.
++
+Data type: RebuildStrategy
+
+`scout.jaxws.consumer.connectTimeout` ::
+Connect timeout in milliseconds to abort a webservice request, if establishment of the connection takes longer than this timeout. A timeout of null means an infinite timeout. The default value is null.
++
+Data type: Integer >= 0
+
+`scout.jaxws.consumer.portCache.corePoolSize` ::
+Number of ports to be preemptively cached to speed up webservice calls. The default value is 10.
++
+Data type: Integer >= 0
+
+`scout.jaxws.consumer.portCache.enabled` ::
+Indicates whether to use a preemptive port cache for webservice clients.
++
 Depending on the implementor used, cached ports may increase performance, because port creation is an expensive operation due to WSDL and schema validation.
-
++
 The cache is based on a `corePoolSize`, meaning that that number of ports is created on a preemptive basis. If more ports than that number is required, they are are created on demand and also added to the cache until expired, which is useful at a high load.
-
++
 The default value is true.
-|Boolean
-|Config Property
-|`scout.jaxws.consumer.portCache.ttl`
-|Maximum time in seconds to retain ports in the cache if the value of `scout.jaxws.consumer.portCache.corePoolSize` is exceeded. That typically occurs at high load, or if `scout.jaxws.consumer.portCache.corePoolSize` is undersized. The default value is 15 minutes.
-|Long >= 0
-|Config Property
-|`scout.jaxws.consumer.portPoolEnabled`
-|To indicate whether to pool webservice clients.
++
+Data type: Boolean
 
+`scout.jaxws.consumer.portCache.ttl` ::
+Maximum time in seconds to retain ports in the cache if the value of `scout.jaxws.consumer.portCache.corePoolSize` is exceeded. That typically occurs at high load, or if `scout.jaxws.consumer.portCache.corePoolSize` is undersized. The default value is 15 minutes.
++
+Data type: Long >= 0
+
+`scout.jaxws.consumer.portPoolEnabled` ::
+To indicate whether to pool webservice clients.
++
 Creating new service and Port instances is expensive due to WSDL and schema validation. Using the pool helps to reduce these costs. The default value is true.
-
++
 The pool size is unlimited but its elements are removed after a certain time (configurable)
-
++
 If this value is true, the value of property `scout.jaxws.consumer.portCache.enabled` has no effect.
-|Boolean
-|Config Property
-|`scout.jaxws.consumer.readTimeout`
-|Read timeout in milliseconds to abort a webservice request, if it takes longer than this timeout for data to be available for read. A timeout of null means an infinite timeout. The default value is null.
-|Integer >= 0
-|Config Property
-|`scout.jaxws.implementor`
-|Fully qualified class name of the JAX-WS implementor to use. The class must extend `org.eclipse.scout.rt.server.jaxws.implementor.JaxWsImplementorSpecifics`.
++
+Data type: Boolean
 
+`scout.jaxws.consumer.readTimeout` ::
+Read timeout in milliseconds to abort a webservice request, if it takes longer than this timeout for data to be available for read. A timeout of null means an infinite timeout. The default value is null.
++
+Data type: Integer >= 0
+
+`scout.jaxws.implementor` ::
+Fully qualified class name of the JAX-WS implementor to use. The class must extend `org.eclipse.scout.rt.server.jaxws.implementor.JaxWsImplementorSpecifics`.
++
 By default JAX-WS Metro (not bundled with JRE) is used. For that to work, add the Maven dependency to JAX-WS Metro to your server application`s pom.xml: com.sun.xml.ws:jaxws-rt:2.3.5.
-|Fully qualified class name. The class must have `org.eclipse.scout.rt.server.jaxws.implementor.JaxWsImplementorSpecifics` in its super hierarchy.
-|Config Property
-|`scout.jaxws.loghandlerDebug`
-|Indicates whether to log SOAP messages in debug or info level. The default value is false.
-|Boolean
-|Config Property
-|`scout.jaxws.provider.authentication.basicRealm`
-|Security Realm used for Basic Authentication; used by `org.eclipse.scout.rt.server.jaxws.provider.auth.method.BasicAuthenticationMethod`. The default value is `JAX-WS`.
-|String
-|Config Property
-|`scout.jaxws.provider.user.authenticator`
-|Technical Subject used to authenticate webservice requests. The default value is `jaxws-authenticator`.
-|Subject name as String
-|Config Property
-|`scout.jaxws.provider.user.handler`
-|Technical subject used to invoke JAX-WS handlers if the request is not authenticated yet; used by `org.eclipse.scout.rt.server.jaxws.provider.handler.HandlerDelegate`.
++
+Data type: Fully qualified class name. The class must have `org.eclipse.scout.rt.server.jaxws.implementor.JaxWsImplementorSpecifics` in its super hierarchy.
 
+`scout.jaxws.loghandlerDebug` ::
+Indicates whether to log SOAP messages in debug or info level. The default value is false.
++
+Data type: Boolean
+
+`scout.jaxws.provider.authentication.basicRealm` ::
+Security Realm used for Basic Authentication; used by `org.eclipse.scout.rt.server.jaxws.provider.auth.method.BasicAuthenticationMethod`. The default value is `JAX-WS`.
++
+Data type: String
+
+`scout.jaxws.provider.user.authenticator` ::
+Technical Subject used to authenticate webservice requests. The default value is `jaxws-authenticator`.
++
+Data type: Subject name as String
+
+`scout.jaxws.provider.user.handler` ::
+Technical subject used to invoke JAX-WS handlers if the request is not authenticated yet; used by `org.eclipse.scout.rt.server.jaxws.provider.handler.HandlerDelegate`.
++
 The default value is `jaxws-handler`.
-|Subject name as String
-|Config Property
-|`scout.jetty.port`
-|The port under which the jetty will be running.
-|Integer between 1 and 65535
-|Config Property
-|`scout.jobmanager.allowCoreThreadTimeOut`
-|Specifies whether threads of the core-pool should be terminated after being idle for longer than the value of property `scout.jobmanager.keepAliveTime`. The defautl value is false.
-|Boolean
-|Config Property
-|`scout.jobmanager.corePoolSize`
-|The number of threads to keep in the pool, even if they are idle. The default value is 25.
-|Integer >= 0
-|Config Property
-|`scout.jobmanager.keepAliveTime`
-|The time limit (in seconds) for which threads, which are created upon exceeding the `scout.jobmanager.corePoolSize` limit, may remain idle before being terminated. The default value is 1 minute.
-|Long >= 0
-|Config Property
-|`scout.jobmanager.maximumPoolSize`
-|The maximal number of threads to be created once the value of `scout.jobmanager.corePoolSize` is exceeded. The default value is unlimited (which means limited by the resources of the machine).
-|Integer >= 0
-|Config Property
-|`scout.jobmanager.prestartCoreThreads`
-|Specifies whether all threads of the core-pool should be started upon job manager startup, so that they are idle waiting for work.
++
+Data type: Subject name as String
 
+`scout.jetty.port` ::
+The port under which the jetty will be running.
++
+Data type: Integer between 1 and 65535
+
+`scout.jobmanager.allowCoreThreadTimeOut` ::
+Specifies whether threads of the core-pool should be terminated after being idle for longer than the value of property `scout.jobmanager.keepAliveTime`. The defautl value is false.
++
+Data type: Boolean
+
+`scout.jobmanager.corePoolSize` ::
+The number of threads to keep in the pool, even if they are idle. The default value is 25.
++
+Data type: Integer >= 0
+
+`scout.jobmanager.keepAliveTime` ::
+The time limit (in seconds) for which threads, which are created upon exceeding the `scout.jobmanager.corePoolSize` limit, may remain idle before being terminated. The default value is 1 minute.
++
+Data type: Long >= 0
+
+`scout.jobmanager.maximumPoolSize` ::
+The maximal number of threads to be created once the value of `scout.jobmanager.corePoolSize` is exceeded. The default value is unlimited (which means limited by the resources of the machine).
++
+Data type: Integer >= 0
+
+`scout.jobmanager.prestartCoreThreads` ::
+Specifies whether all threads of the core-pool should be started upon job manager startup, so that they are idle waiting for work.
++
 By default this is disabled in development mode (property `scout.devMode` is true) and enabled otherwise.
-|Boolean
-|Config Property
-|`scout.loadWebResourcesFromFilesystem`
-|Specifies if the application should look for web resources (like .js, .html or .css) on the local filesystem. If true, the resources will be searched in modules that follow the Scout naming conventions (e.g. name.ui.app.dev, name.ui.app, name.ui) on the local filesystem first and (if not found) on the classpath second. If false, the resources are searched on the Java classpath only. By default this property is true in dev mode and false otherwise.
-|Boolean
-|Config Property
-|`scout.mail.bouncedetector.heuristic.contents`
-|Non standard email bounce detection: content is checked against the provided list of heuristic contents (partial match, case-insensitive)
-|List
-|Config Property
-|`scout.mail.bouncedetector.heuristic.senderPrefixes`
-|Non standard email bounce detection: sender is checked against the provided list of heuristic sender prefixes (prefix match, case-insensitive)
-|List
-|Config Property
-|`scout.mail.bouncedetector.heuristic.subjects`
-|Non standard email bounce detection: subject is checked against the provided list of heuristic subjects (partial match, case-insensitive)
-|List
-|Config Property
-|`scout.malwareScanner.path`
-|Path to a malware scanner checked directory. The default value is null which means the system temp path is used.
-|String
-|Config Property
-|`scout.mom.cluster.destination.clusterNotificationTopic`
-|Name of the topic for cluster notifications published by scout application.
-|IDestination
-|Config Property
-|`scout.mom.cluster.environment`
-|Contains the configuration to connect to the network or broker. This configuration is specific to the MOM implementor
++
+Data type: Boolean
 
+`scout.loadWebResourcesFromFilesystem` ::
+Specifies if the application should look for web resources (like .js, .html or .css) on the local filesystem. If true, the resources will be searched in modules that follow the Scout naming conventions (e.g. name.ui.app.dev, name.ui.app, name.ui) on the local filesystem first and (if not found) on the classpath second. If false, the resources are searched on the Java classpath only. By default this property is true in dev mode and false otherwise.
++
+Data type: Boolean
+
+`scout.mail.bouncedetector.heuristic.contents` ::
+Non standard email bounce detection: content is checked against the provided list of heuristic contents (partial match, case-insensitive)
++
+Data type: List
+
+`scout.mail.bouncedetector.heuristic.senderPrefixes` ::
+Non standard email bounce detection: sender is checked against the provided list of heuristic sender prefixes (prefix match, case-insensitive)
++
+Data type: List
+
+`scout.mail.bouncedetector.heuristic.subjects` ::
+Non standard email bounce detection: subject is checked against the provided list of heuristic subjects (partial match, case-insensitive)
++
+Data type: List
+
+`scout.malwareScanner.path` ::
+Path to a malware scanner checked directory. The default value is null which means the system temp path is used.
++
+Data type: String
+
+`scout.mom.cluster.destination.clusterNotificationTopic` ::
+Name of the topic for cluster notifications published by scout application.
++
+Data type: IDestination
+
+`scout.mom.cluster.environment` ::
+Contains the configuration to connect to the network or broker. This configuration is specific to the MOM implementor
++
 Example to connect to a peer based cluster, which is useful in development mode because there is no central broker:
-
++
+[listing]
 scout.mom.cluster.environment[scout.mom.name]=Scout Cluster MOM
-
 scout.mom.cluster.environment[scout.mom.connectionfactory.name]=ClusterMom
-
 scout.mom.cluster.environment[java.naming.factory.initial]=org.apache.activemq.jndi.ActiveMQInitialContextFactory
-
 scout.mom.cluster.environment[java.naming.provider.url]=failover:(peer://mom/cluster?persistent=false)
-
 scout.mom.cluster.environment[connectionFactoryNames]=ClusterMom
-|Map
-|Config Property
-|`scout.mom.cluster.implementor`
-|Specifies the MOM implementor.
++
+Data type: Map
 
+`scout.mom.cluster.implementor` ::
+Specifies the MOM implementor.
++
 Example to work with a JMS based implementor:
-
++
+[listing]
 scout.mom.cluster.implementor=org.eclipse.scout.rt.mom.jms.JmsMomImplementor
-|Fully qualified class name. The class must have `org.eclipse.scout.rt.mom.api.IMomImplementor` in its super hierarchy.
-|Config Property
-|`scout.mom.failover.connectionRetryCount`
-|Specifies the connection retry count for connection failover. Default is 15. The value 0 disables connection failover.
-|Integer
-|Config Property
-|`scout.mom.failover.connectionRetryIntervalMillis`
-|Specifies the connection retry interval in milliseconds. Default is 2000ms.
-|Integer
-|Config Property
-|`scout.mom.failover.sessionRetryIntervalMillis`
-|Specifies the session retry interval in milliseconds. Default is 5000ms.
-|Integer
-|Config Property
-|`scout.mom.marshaller`
-|Specifies the default Marshaller to use if no marshaller is specified for a MOM or a destination. By default the `JsonDataObjectMarshaller` is used.
-|Fully qualified class name. The class must have `org.eclipse.scout.rt.mom.api.marshaller.IMarshaller` in its super hierarchy.
-|Config Property
-|`scout.mom.requestreply.cancellationTopic`
-|Specifies the default topic to receive cancellation request for `request-reply` communication. By default a defined topic with the name `scout.mom.requestreply.cancellation` is used.
-|IDestination
-|Config Property
-|`scout.mom.requestreply.enabled`
-|Specifies if `request-reply` messaging is enabled by default. This value can also be configured individually per MOM. The default value is true.
-|Boolean
-|Config Property
-|`scout.nodeId`
-|Specifies the cluster node name. If not specified a default id is computed.
-|String
-|Config Property
-|`scout.remotefileRootPath`
-|Absolute path to the root directory of the `RemoteFileService`. The default value is null.
-|String
-|Config Property
-|`scout.serverSessionTtl`
-|Server sessions that have not been accessed for the specified number of milliseconds are removed from the cache. The default value is one day.
-|Long >= 0
-|Config Property
-|`scout.servicetunnel.compress`
-|Specifies if the service tunnel should compress the data. If null, the response decides which is default to true.
-|Boolean
-|Config Property
-|`scout.servicetunnel.maxConnectionsPerRoute`
-|Specifies the default maximum connections per route property for the HTTP service tunnel.
++
+Data type: Fully qualified class name. The class must have `org.eclipse.scout.rt.mom.api.IMomImplementor` in its super hierarchy.
 
+`scout.mom.failover.connectionRetryCount` ::
+Specifies the connection retry count for connection failover. Default is 15. The value 0 disables connection failover.
++
+Data type: Integer
+
+`scout.mom.failover.connectionRetryIntervalMillis` ::
+Specifies the connection retry interval in milliseconds. Default is 2000ms.
++
+Data type: Integer
+
+`scout.mom.failover.sessionRetryIntervalMillis` ::
+Specifies the session retry interval in milliseconds. Default is 5000ms.
++
+Data type: Integer
+
+`scout.mom.marshaller` ::
+Specifies the default Marshaller to use if no marshaller is specified for a MOM or a destination. By default the `JsonDataObjectMarshaller` is used.
++
+Data type: Fully qualified class name. The class must have `org.eclipse.scout.rt.mom.api.marshaller.IMarshaller` in its super hierarchy.
+
+`scout.mom.requestreply.cancellationTopic` ::
+Specifies the default topic to receive cancellation request for `request-reply` communication. By default a defined topic with the name `scout.mom.requestreply.cancellation` is used.
++
+Data type: IDestination
+
+`scout.mom.requestreply.enabled` ::
+Specifies if `request-reply` messaging is enabled by default. This value can also be configured individually per MOM. The default value is true.
++
+Data type: Boolean
+
+`scout.nodeId` ::
+Specifies the cluster node name. If not specified a default id is computed.
++
+Data type: String
+
+`scout.remotefileRootPath` ::
+Absolute path to the root directory of the `RemoteFileService`. The default value is null.
++
+Data type: String
+
+`scout.serverSessionTtl` ::
+Server sessions that have not been accessed for the specified number of milliseconds are removed from the cache. The default value is one day.
++
+Data type: Long >= 0
+
+`scout.servicetunnel.compress` ::
+Specifies if the service tunnel should compress the data. If null, the response decides which is default to true.
++
+Data type: Boolean
+
+`scout.servicetunnel.maxConnectionsPerRoute` ::
+Specifies the default maximum connections per route property for the HTTP service tunnel.
++
 Overrides the value from `scout.http.maxConnectionsPerRoute` for the service tunnel.
-
++
 Default value is 2048.
-|Integer
-|Config Property
-|`scout.servicetunnel.maxConnectionsTotal`
-|Specifies the default total maximum connections property for the HTTP service tunnel.
++
+Data type: Integer
 
+`scout.servicetunnel.maxConnectionsTotal` ::
+Specifies the default total maximum connections property for the HTTP service tunnel.
++
 Overrides the value from `scout.http.maxConnectionsTotal` for the service tunnel.
-
++
 The default value is 2048.
-|Integer
-|Config Property
-|`scout.servicetunnel.targetUrl`
-|Specifies the URL to the ServiceTunnelServlet on the backend server.
++
+Data type: Integer
 
+`scout.servicetunnel.targetUrl` ::
+Specifies the URL to the ServiceTunnelServlet on the backend server.
++
 By default this property points to the value of property `scout.backendUrl` with `/process` appended.
-|String
-|Config Property
-|`scout.smtp.connectionTimeout`
-|Socket connection timeout value in milliseconds.
-|Integer >= 0
-|Config Property
-|`scout.smtp.debugReceiverEmail`
-|If specified all emails are sent to this address instead of the real one. This may be useful during development to not send emails to real users by accident.
-|String
-|Config Property
-|`scout.smtp.pool.maxConnectionLifetime`
-|Max. lifetime of pooled connections in seconds.
-|Integer >= 0
-|Config Property
-|`scout.smtp.pool.maxIdleTime`
-|Max. idle time for pooled connections in seconds.
-|Integer >= 0
-|Config Property
-|`scout.smtp.pool.waitForConnectionTimeout`
-|Max. wait time for SMTP connection in seconds. If the value is 0, callers will wait infinitely long for SMTP connections.
-|Integer >= 0
-|Config Property
-|`scout.smtp.readTimeout`
-|Socket read timeout value in milliseconds.
-|Integer >= 0
-|Config Property
-|`scout.sql.directJdbcConnection`
-|If true a direct JDBC connection is created. Otherwise a JNDI connection is used. The default value is true.
-|Boolean
-|Config Property
-|`scout.sql.jdbc.driverName`
-|The driver name to use. By default `oracle.jdbc.OracleDriver` is used.
-|String
-|Config Property
-|`scout.sql.jdbc.mappingName`
-|The JDBC mapping name. By default `jdbc:oracle:thin:@localhost:1521:ORCL` is used.
-|String
-|Config Property
-|`scout.sql.jdbc.pool.connectionBusyTimeout`
-|Connections will be closed after this timeout in milliseconds even if the connection is still busy. The default value is 6 hours.
-|Long >= 0
-|Config Property
-|`scout.sql.jdbc.pool.connectionIdleTimeout`
-|Idle connections will be closed after this timeout in milliseconds. The default value is 5 minutes.
-|Long >= 0
-|Config Property
-|`scout.sql.jdbc.pool.size`
-|The maximum number of connections to create. The default pool size is 25.
-|Integer >= 0
-|Config Property
-|`scout.sql.jdbc.properties`
-|Semicolon separated list of properties to pass to the JDBC connection. The default value is null. E.g.: key1=val1;key2=val2
-|String
-|Config Property
-|`scout.sql.jdbc.statementCacheSize`
-|Maximum number of cached SQL statements. The default value is 25.
-|Integer >= 0
-|Config Property
-|`scout.sql.jndi.initialContextFactory`
-|The name of the object to lookup in the JNDI context. Default is null.
-|String
-|Config Property
-|`scout.sql.jndi.name`
-|The name of the object to lookup in the JNDI context. Default is null.
-|String
-|Config Property
-|`scout.sql.jndi.providerUrl`
-|JNDI provider url (e.g. `ldap://somehost:389`). Default is null.
-|String
-|Config Property
-|`scout.sql.jndi.urlPkgPrefixes`
-|A colon-separated list of package prefixes for the class name of the factory class that will create a URL context factory. Default is null.
-|String
-|Config Property
-|`scout.sql.password`
-|The password to connect to the database (JDBC or JNDI)
-|String
-|Config Property
-|`scout.sql.transactionMemberId`
-|Id of the transaction member on which the connection is available.
-|String
-|Config Property
-|`scout.sql.username`
-|The username to connect to the database (JDBC or JNDI)
-|String
-|Config Property
-|`scout.texts.showKeys`
-|If this property is set to true, the `TextKeyTextProviderService` will be registered with high priority, and each call to TEXTS.get() will return the given text key instead of the translation.
++
+Data type: String
 
+`scout.smtp.connectionTimeout` ::
+Socket connection timeout value in milliseconds.
++
+Data type: Integer >= 0
+
+`scout.smtp.debugReceiverEmail` ::
+If specified all emails are sent to this address instead of the real one. This may be useful during development to not send emails to real users by accident.
++
+Data type: String
+
+`scout.smtp.pool.maxConnectionLifetime` ::
+Max. lifetime of pooled connections in seconds.
++
+Data type: Integer >= 0
+
+`scout.smtp.pool.maxIdleTime` ::
+Max. idle time for pooled connections in seconds.
++
+Data type: Integer >= 0
+
+`scout.smtp.pool.waitForConnectionTimeout` ::
+Max. wait time for SMTP connection in seconds. If the value is 0, callers will wait infinitely long for SMTP connections.
++
+Data type: Integer >= 0
+
+`scout.smtp.readTimeout` ::
+Socket read timeout value in milliseconds.
++
+Data type: Integer >= 0
+
+`scout.sql.directJdbcConnection` ::
+If true a direct JDBC connection is created. Otherwise a JNDI connection is used. The default value is true.
++
+Data type: Boolean
+
+`scout.sql.jdbc.driverName` ::
+The driver name to use. By default `oracle.jdbc.OracleDriver` is used.
++
+Data type: String
+
+`scout.sql.jdbc.mappingName` ::
+The JDBC mapping name. By default `jdbc:oracle:thin:@localhost:1521:ORCL` is used.
++
+Data type: String
+
+`scout.sql.jdbc.pool.connectionBusyTimeout` ::
+Connections will be closed after this timeout in milliseconds even if the connection is still busy. The default value is 6 hours.
++
+Data type: Long >= 0
+
+`scout.sql.jdbc.pool.connectionIdleTimeout` ::
+Idle connections will be closed after this timeout in milliseconds. The default value is 5 minutes.
++
+Data type: Long >= 0
+
+`scout.sql.jdbc.pool.size` ::
+The maximum number of connections to create. The default pool size is 25.
++
+Data type: Integer >= 0
+
+`scout.sql.jdbc.properties` ::
+Semicolon separated list of properties to pass to the JDBC connection. The default value is null. E.g.: key1=val1;key2=val2
++
+Data type: String
+
+`scout.sql.jdbc.statementCacheSize` ::
+Maximum number of cached SQL statements. The default value is 25.
++
+Data type: Integer >= 0
+
+`scout.sql.jndi.initialContextFactory` ::
+The name of the object to lookup in the JNDI context. Default is null.
++
+Data type: String
+
+`scout.sql.jndi.name` ::
+The name of the object to lookup in the JNDI context. Default is null.
++
+Data type: String
+
+`scout.sql.jndi.providerUrl` ::
+JNDI provider url (e.g. `ldap://somehost:389`). Default is null.
++
+Data type: String
+
+`scout.sql.jndi.urlPkgPrefixes` ::
+A colon-separated list of package prefixes for the class name of the factory class that will create a URL context factory. Default is null.
++
+Data type: String
+
+`scout.sql.password` ::
+The password to connect to the database (JDBC or JNDI)
++
+Data type: String
+
+`scout.sql.transactionMemberId` ::
+Id of the transaction member on which the connection is available.
++
+Data type: String
+
+`scout.sql.username` ::
+The username to connect to the database (JDBC or JNDI)
++
+Data type: String
+
+`scout.texts.showKeys` ::
+If this property is set to true, the `TextKeyTextProviderService` will be registered with high priority, and each call to TEXTS.get() will return the given text key instead of the translation.
++
 This is useful for debug/testing purposes or exporting forms to JSON.
-
++
 By default this property is false.
-|Boolean
-|Config Property
-|`scout.tiles.dataLoadQueueTimeoutSeconds`
-|Maximum number of seconds a tile load job can execute until it is automatically cancelled. The default value is 2 minutes.
-|Integer >= 0
-|Config Property
-|`scout.tiles.maxConcurrentDataLoadThreads`
-|Maximum number of threads per server that can be created to load tiles. The default value is 25.
-|Integer >= 0
-|Config Property
-|`scout.trustedCertificates`
-|URIs to DER (Base64) encoded certificate files that should be trusted. The URI may refer to a local file or a resource on the classpath (use classpath: prefix). The default value is an empty list.
-|List
-|Config Property
-|`scout.ui.backgroundPollingMaxWaitTime`
-|The polling request (which waits for a background job to complete) stays open until a background job has completed or the specified number of seconds elapsed.
++
+Data type: Boolean
 
+`scout.tiles.dataLoadQueueTimeoutSeconds` ::
+Maximum number of seconds a tile load job can execute until it is automatically cancelled. The default value is 2 minutes.
++
+Data type: Integer >= 0
+
+`scout.tiles.maxConcurrentDataLoadThreads` ::
+Maximum number of threads per server that can be created to load tiles. The default value is 25.
++
+Data type: Integer >= 0
+
+`scout.trustedCertificates` ::
+URIs to DER (Base64) encoded certificate files that should be trusted. The URI may refer to a local file or a resource on the classpath (use classpath: prefix). The default value is an empty list.
++
+Data type: List
+
+`scout.ui.backgroundPollingMaxWaitTime` ::
+The polling request (which waits for a background job to complete) stays open until a background job has completed or the specified number of seconds elapsed.
++
 This property must have a value between 3 and the value of property `scout.ui.maxUserIdleTime`.
-
++
 By default this property is set to 1 minute.
-|Long >= 0
-|Config Property
-|`scout.ui.locales`
-|Contains a comma separated list of supported locales (e.g. en,en-US,de-CH).
++
+Data type: Long >= 0
 
+`scout.ui.locales` ::
+Contains a comma separated list of supported locales (e.g. en,en-US,de-CH).
++
 This is only relevant if locales.json and texts.json should be sent to the client, which is not the case for remote apps. So this property is only used for JS only apps.
-
++
 By default no locales are supported.
-|List
-|Config Property
-|`scout.ui.maxUserIdleTime`
-|If a user is inactive (no user action) for the specified number of seconds, the session is stopped and the user is logged out.
++
+Data type: List
 
+`scout.ui.maxUserIdleTime` ::
+If a user is inactive (no user action) for the specified number of seconds, the session is stopped and the user is logged out.
++
 By default this property is set to 4 hours.
-|Long >= 0
-|Config Property
-|`scout.ui.modelJobTimeout`
-|The maximal timeout in seconds to wait for model jobs to complete during a UI request. After that timeout the model jobs will be aborted so that the request may return to the client.
++
+Data type: Long >= 0
 
+`scout.ui.modelJobTimeout` ::
+The maximal timeout in seconds to wait for model jobs to complete during a UI request. After that timeout the model jobs will be aborted so that the request may return to the client.
++
 By default this property is set to 1 hour.
-|Long >= 0
-|Config Property
-|`scout.ui.sessionstore.housekeepingDelay`
-|Number of seconds before the housekeeping job starts after a UI session has been unregistered from the store.
++
+Data type: Long >= 0
 
+`scout.ui.sessionstore.housekeepingDelay` ::
+Number of seconds before the housekeeping job starts after a UI session has been unregistered from the store.
++
 By default this property is set to 30 seconds.
-|Integer >= 0
-|Config Property
-|`scout.ui.theme`
-|The name of the UI theme which is activated when the application starts.
-|String
-|Config Property
-|`scout.urlHints.enabled`
-|Enable or disable changing UrlHints using URL parameters in the browser address line.
++
+Data type: Integer >= 0
 
+`scout.ui.theme` ::
+The name of the UI theme which is activated when the application starts.
++
+Data type: String
+
+`scout.urlHints.enabled` ::
+Enable or disable changing UrlHints using URL parameters in the browser address line.
++
 By default has the same value as the config property `scout.devMode` meaning it is by default only enabled in development mode.
-|Boolean
-|Config Property
-|`scout.util.defaultDecimalSupportProvider`
-|Specifies the default DefaultDecimalSupportProvider to use. By default the `DefaultDecimalSupportProvider` is used.
-|Fully qualified class name. The class must have `org.eclipse.scout.rt.platform.util.DECIMAL$DefaultDecimalSupportProvider` in its super hierarchy.
-|Config Property
-|===
++
+Data type: Boolean
+
+`scout.util.defaultDecimalSupportProvider` ::
+Specifies the default DefaultDecimalSupportProvider to use. By default the `DefaultDecimalSupportProvider` is used.
++
+Data type: Fully qualified class name. The class must have `org.eclipse.scout.rt.platform.util.DECIMAL$DefaultDecimalSupportProvider` in its super hierarchy.

--- a/docs/playbooks/test-eclipse-scout-playbook.yml
+++ b/docs/playbooks/test-eclipse-scout-playbook.yml
@@ -1,0 +1,19 @@
+# This file is useful for testing local changes in your working
+# directory before merging them into a release Branch.
+
+site:
+  title: Eclipse Scout
+  start_page: scout-docs:ROOT:index.adoc
+content:
+  sources:
+  - url: ./../..
+    branches: HEAD
+    start_path: docs
+ui:
+  bundle:
+    url: ./eclipse-scout-ui-bundle.zip
+    snapshot: true
+antora:
+  extensions:
+  - require: '@antora/lunr-extension'
+    languages: [en]


### PR DESCRIPTION
The old table did not work well with the new CSS.

- Change to definition list
- Drop the last column (Kind was always Config Propertiy)
- Use [listing] for examples where appropriate
- For those examples that didn't include the property, include it now
- Drop the dead links to Apache HTTP Components