### PR TITLE
Scout JS: rename menuType constants and types

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
@@ -417,9 +417,9 @@ export default (): FormModel => ({
                     objectType: Menu,
                     text: 'Add dataset',
                     menuTypes: [
-                      Table.MenuTypes.EmptySpace,
-                      Table.MenuTypes.SingleSelection,
-                      Table.MenuTypes.MultiSelection
+                      Table.MenuType.EmptySpace,
+                      Table.MenuType.SingleSelection,
+                      Table.MenuType.MultiSelection
                     ]
                   },
                   {
@@ -427,8 +427,8 @@ export default (): FormModel => ({
                     objectType: Menu,
                     text: 'Remove dataset',
                     menuTypes: [
-                      Table.MenuTypes.SingleSelection,
-                      Table.MenuTypes.MultiSelection
+                      Table.MenuType.SingleSelection,
+                      Table.MenuType.MultiSelection
                     ]
                   },
                   {
@@ -437,7 +437,7 @@ export default (): FormModel => ({
                     iconId: icons.PLUS,
                     tooltipText: 'Add data',
                     menuTypes: [
-                      Table.MenuTypes.Header
+                      Table.MenuType.Header
                     ]
                   },
                   {
@@ -447,7 +447,7 @@ export default (): FormModel => ({
                     tooltipText: 'Remove data',
                     enabled: false,
                     menuTypes: [
-                      Table.MenuTypes.Header
+                      Table.MenuType.Header
                     ]
                   }
                 ]

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/common/ConfigurationBox.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/common/ConfigurationBox.ts
@@ -26,7 +26,7 @@ export class ConfigurationBox extends TabBox {
       parent: this,
       cssClass: 'configuration-box-toggle-menu',
       menuTypes: [
-        TabBox.MenuTypes.Header
+        TabBox.MenuType.Header
       ]
     });
     this.toggleMenu.on('action', this._onToggleMenuAction.bind(this));

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTableModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTableModel.ts
@@ -57,7 +57,7 @@ export default (): PageModel => ({
         objectType: FormMenu,
         text: 'Form menu',
         menuTypes: [
-          Table.MenuTypes.EmptySpace, Table.MenuTypes.SingleSelection
+          Table.MenuType.EmptySpace, Table.MenuType.SingleSelection
         ],
         form: {
           objectType: MiniForm
@@ -68,7 +68,7 @@ export default (): PageModel => ({
         objectType: Menu,
         text: '${textKey:AddRow}',
         menuTypes: [
-          Table.MenuTypes.EmptySpace
+          Table.MenuType.EmptySpace
         ],
         keyStroke: 'insert'
       },
@@ -77,7 +77,7 @@ export default (): PageModel => ({
         objectType: Menu,
         text: 'Add many',
         menuTypes: [
-          Table.MenuTypes.EmptySpace
+          Table.MenuType.EmptySpace
         ]
       },
       {
@@ -85,8 +85,8 @@ export default (): PageModel => ({
         objectType: Menu,
         text: '${textKey:DeleteRow}',
         menuTypes: [
-          Table.MenuTypes.SingleSelection,
-          Table.MenuTypes.MultiSelection
+          Table.MenuType.SingleSelection,
+          Table.MenuType.MultiSelection
         ],
         keyStroke: 'delete'
       },
@@ -97,7 +97,7 @@ export default (): PageModel => ({
         stackable: false,
         horizontalAlignment: 1,
         menuTypes: [
-          Table.MenuTypes.EmptySpace
+          Table.MenuType.EmptySpace
         ]
       }
     ],

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tabbox/TabBoxFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tabbox/TabBoxFormModel.ts
@@ -55,7 +55,7 @@ export default (): FormModel => ({
                 iconId: icons.PLUS,
                 stackable: true,
                 menuTypes: [
-                  TabBox.MenuTypes.Header
+                  TabBox.MenuType.Header
                 ],
                 keyStroke: 'insert'
               },
@@ -66,7 +66,7 @@ export default (): FormModel => ({
                 iconId: icons.MINUS,
                 stackable: true,
                 menuTypes: [
-                  TabBox.MenuTypes.Header
+                  TabBox.MenuType.Header
                 ],
                 keyStroke: 'insert'
               },
@@ -76,7 +76,7 @@ export default (): FormModel => ({
                 iconId: icons.GEAR,
                 stackable: false,
                 menuTypes: [
-                  TabBox.MenuTypes.Header
+                  TabBox.MenuType.Header
                 ],
                 horizontalAlignment: 1
               }

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
@@ -93,7 +93,7 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:AddRow}',
                   menuTypes: [
-                    Table.MenuTypes.EmptySpace
+                    Table.MenuType.EmptySpace
                   ],
                   keyStroke: 'insert'
                 },
@@ -102,7 +102,7 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:Move}',
                   menuTypes: [
-                    Table.MenuTypes.SingleSelection
+                    Table.MenuType.SingleSelection
                   ],
                   childActions: [
                     {
@@ -110,7 +110,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveToTop}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     },
                     {
@@ -118,7 +118,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveUp}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     },
                     {
@@ -126,7 +126,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveDown}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     },
                     {
@@ -134,7 +134,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveToBottom}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     }
                   ]
@@ -144,8 +144,8 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:DeleteRow}',
                   menuTypes: [
-                    Table.MenuTypes.SingleSelection,
-                    Table.MenuTypes.MultiSelection
+                    Table.MenuType.SingleSelection,
+                    Table.MenuType.MultiSelection
                   ],
                   keyStroke: 'delete'
                 }

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTableFormModel.ts
@@ -72,25 +72,25 @@ export default (): FormModel => ({
                   id: 'ContentMenu',
                   objectType: Menu,
                   text: 'Content',
-                  menuTypes: [Table.MenuTypes.EmptySpace],
+                  menuTypes: [Table.MenuType.EmptySpace],
                   childActions: [
                     {
                       id: 'RemoveAll',
                       objectType: Menu,
                       text: 'Remove all rows',
-                      menuTypes: [Table.MenuTypes.EmptySpace]
+                      menuTypes: [Table.MenuType.EmptySpace]
                     },
                     {
                       id: 'InsertFew',
                       objectType: Menu,
                       text: 'Insert few',
-                      menuTypes: [Table.MenuTypes.EmptySpace]
+                      menuTypes: [Table.MenuType.EmptySpace]
                     },
                     {
                       id: 'InsertMany',
                       objectType: Menu,
                       text: 'Insert many',
-                      menuTypes: [Table.MenuTypes.EmptySpace]
+                      menuTypes: [Table.MenuType.EmptySpace]
                     }
                   ]
                 },
@@ -98,14 +98,14 @@ export default (): FormModel => ({
                   id: 'AddRowMenu',
                   objectType: Menu,
                   text: '${textKey:AddRow}',
-                  menuTypes: [Table.MenuTypes.EmptySpace],
+                  menuTypes: [Table.MenuType.EmptySpace],
                   keyStroke: 'insert'
                 },
                 {
                   id: 'DeleteRowMenu',
                   objectType: Menu,
                   text: '${textKey:DeleteRow}',
-                  menuTypes: [Table.MenuTypes.SingleSelection, Table.MenuTypes.MultiSelection],
+                  menuTypes: [Table.MenuType.SingleSelection, Table.MenuType.MultiSelection],
                   keyStroke: 'delete'
                 }
               ]

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tree/TreeFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tree/TreeFormModel.ts
@@ -41,7 +41,7 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:AddNode}',
                   menuTypes: [
-                    Tree.MenuTypes.EmptySpace
+                    Tree.MenuType.EmptySpace
                   ],
                   keyStroke: 'insert'
                 },
@@ -50,7 +50,7 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:AddChildNode}',
                   menuTypes: [
-                    Tree.MenuTypes.EmptySpace
+                    Tree.MenuType.EmptySpace
                   ],
                   keyStroke: 'insert'
                 },
@@ -59,8 +59,8 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:DeleteNode}',
                   menuTypes: [
-                    Tree.MenuTypes.SingleSelection,
-                    Tree.MenuTypes.MultiSelection
+                    Tree.MenuType.SingleSelection,
+                    Tree.MenuType.MultiSelection
                   ],
                   keyStroke: 'delete'
                 },
@@ -69,7 +69,7 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:DeleteAll}',
                   menuTypes: [
-                    Tree.MenuTypes.EmptySpace
+                    Tree.MenuType.EmptySpace
                   ],
                   childActions: [
                     {
@@ -77,7 +77,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:DeleteAllNodes}',
                       menuTypes: [
-                        Tree.MenuTypes.EmptySpace
+                        Tree.MenuType.EmptySpace
                       ]
                     },
                     {
@@ -85,7 +85,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:DeleteAllChildNodes}',
                       menuTypes: [
-                        Tree.MenuTypes.EmptySpace
+                        Tree.MenuType.EmptySpace
                       ]
                     }
                   ]

--- a/docs/modules/releasenotes/partials/release-notes-23.1.adoc
+++ b/docs/modules/releasenotes/partials/release-notes-23.1.adoc
@@ -240,7 +240,7 @@ import {Menu, Table} from '@eclipse-scout/core';
   text: 'Example',
   objectType: Menu,
   menuTypes: [
-    Table.MenuTypes.SingleSelection
+    Table.MenuType.SingleSelection
   ]
 }
 ----

--- a/docs/modules/technical-guide/pages/user-interface/widget-reference.adoc
+++ b/docs/modules/technical-guide/pages/user-interface/widget-reference.adoc
@@ -325,8 +325,8 @@ Please refer to the respective container for the available menu types and their 
 
 === ValueField
 
-The `ValueField` support the menu types `ValueField.MenuTypes.Null` and `ValueField.MenuTypes.NotNull`.
-This means that the `ValueField` will only display menus with `ValueField.MenuTypes.Null` if the value is `null` or those with `ValueField.MenuTypes.NotNull` if the value is set.
+The `ValueField` support the menu types `ValueField.MenuType.Null` and `ValueField.MenuType.NotNull`.
+This means that the `ValueField` will only display menus with `ValueField.MenuType.Null` if the value is `null` or those with `ValueField.MenuType.NotNull` if the value is set.
 
 Menus added to a `ValueField` that need to be visible all the time do not need to specify all possible menu types.
 The `ValueField` will treat a menu without menu types as if it had set all menu types and therefore will always display it.
@@ -346,7 +346,7 @@ import {Menu, ValueField} from '@eclipse-scout/core';
     text: 'Visible if value is null',
     objectType: Menu,
     menuTypes: [
-      ValueField.MenuTypes.Null
+      ValueField.MenuType.Null
     ]
   }
 ]
@@ -354,4 +354,4 @@ import {Menu, ValueField} from '@eclipse-scout/core';
 
 === ImageField
 
-The `ImageField` supports the menu types `ImageField.MenuTypes.ImageUrl` and `ImageField.MenuTypes.Null`.
+The `ImageField` supports the menu types `ImageField.MenuType.ImageUrl` and `ImageField.MenuType.Null`.


### PR DESCRIPTION
constants:
* Calendar.MenuTypes -> Calendar.MenuType
* ImageField.MenuTypes -> ImageField.MenuType
* Planner.MenuTypes -> Planner.MenuType
* TabBox.MenuTypes -> TabBox.MenuType
* Table.MenuTypes -> Table.MenuType
* TileGrid.MenuTypes -> TileGrid.MenuType
* Tree.MenuTypes -> Tree.MenuType
* ValueField.MenuTypes -> ValueField.MenuType types:
* CalendarMenuTypes -> CalendarMenuType
* ImageFieldMenuTypes -> ImageFieldMenuType
* PlannerMenuTypes -> PlannerMenuType
* TabBoxMenuTypes -> TabBoxMenuType
* TableMenuTypes -> TableMenuType
* TileGridMenuTypes -> TileGridMenuType
* TreeMenuTypes -> TreeMenuType
* ValueFieldMenuTypes -> ValueFieldMenuType