### PR TITLE
Scout JS: rename menuType constants and types

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
@@ -417,9 +417,9 @@ export default (): FormModel => ({
                     objectType: Menu,
                     text: 'Add dataset',
                     menuTypes: [
-                      Table.MenuTypes.EmptySpace,
-                      Table.MenuTypes.SingleSelection,
-                      Table.MenuTypes.MultiSelection
+                      Table.MenuType.EmptySpace,
+                      Table.MenuType.SingleSelection,
+                      Table.MenuType.MultiSelection
                     ]
                   },
                   {
@@ -427,8 +427,8 @@ export default (): FormModel => ({
                     objectType: Menu,
                     text: 'Remove dataset',
                     menuTypes: [
-                      Table.MenuTypes.SingleSelection,
-                      Table.MenuTypes.MultiSelection
+                      Table.MenuType.SingleSelection,
+                      Table.MenuType.MultiSelection
                     ]
                   },
                   {
@@ -437,7 +437,7 @@ export default (): FormModel => ({
                     iconId: icons.PLUS,
                     tooltipText: 'Add data',
                     menuTypes: [
-                      Table.MenuTypes.Header
+                      Table.MenuType.Header
                     ]
                   },
                   {
@@ -447,7 +447,7 @@ export default (): FormModel => ({
                     tooltipText: 'Remove data',
                     enabled: false,
                     menuTypes: [
-                      Table.MenuTypes.Header
+                      Table.MenuType.Header
                     ]
                   }
                 ]

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/common/ConfigurationBox.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/common/ConfigurationBox.ts
@@ -26,7 +26,7 @@ export class ConfigurationBox extends TabBox {
       parent: this,
       cssClass: 'configuration-box-toggle-menu',
       menuTypes: [
-        TabBox.MenuTypes.Header
+        TabBox.MenuType.Header
       ]
     });
     this.toggleMenu.on('action', this._onToggleMenuAction.bind(this));

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTableModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTableModel.ts
@@ -58,7 +58,7 @@ export default (): PageModel => ({
         objectType: FormMenu,
         text: 'Form menu',
         menuTypes: [
-          Table.MenuTypes.EmptySpace, Table.MenuTypes.SingleSelection
+          Table.MenuType.EmptySpace, Table.MenuType.SingleSelection
         ],
         form: {
           objectType: MiniForm
@@ -80,8 +80,8 @@ export default (): PageModel => ({
         objectType: Menu,
         text: '${textKey:DeleteRow}',
         menuTypes: [
-          Table.MenuTypes.SingleSelection,
-          Table.MenuTypes.MultiSelection
+          Table.MenuType.SingleSelection,
+          Table.MenuType.MultiSelection
         ],
         keyStroke: 'delete'
       },

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tabbox/TabBoxFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tabbox/TabBoxFormModel.ts
@@ -55,7 +55,7 @@ export default (): FormModel => ({
                 iconId: icons.PLUS,
                 stackable: true,
                 menuTypes: [
-                  TabBox.MenuTypes.Header
+                  TabBox.MenuType.Header
                 ],
                 keyStroke: 'insert'
               },
@@ -66,7 +66,7 @@ export default (): FormModel => ({
                 iconId: icons.MINUS,
                 stackable: true,
                 menuTypes: [
-                  TabBox.MenuTypes.Header
+                  TabBox.MenuType.Header
                 ],
                 keyStroke: 'insert'
               },
@@ -76,7 +76,7 @@ export default (): FormModel => ({
                 iconId: icons.GEAR,
                 stackable: false,
                 menuTypes: [
-                  TabBox.MenuTypes.Header
+                  TabBox.MenuType.Header
                 ],
                 horizontalAlignment: 1
               }

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/TableFormModel.ts
@@ -99,7 +99,7 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:Move}',
                   menuTypes: [
-                    Table.MenuTypes.SingleSelection
+                    Table.MenuType.SingleSelection
                   ],
                   childActions: [
                     {
@@ -107,7 +107,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveToTop}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     },
                     {
@@ -115,7 +115,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveUp}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     },
                     {
@@ -123,7 +123,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveDown}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     },
                     {
@@ -131,7 +131,7 @@ export default (): FormModel => ({
                       objectType: Menu,
                       text: '${textKey:MoveToBottom}',
                       menuTypes: [
-                        Table.MenuTypes.SingleSelection
+                        Table.MenuType.SingleSelection
                       ]
                     }
                   ]
@@ -141,8 +141,8 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:DeleteRow}',
                   menuTypes: [
-                    Table.MenuTypes.SingleSelection,
-                    Table.MenuTypes.MultiSelection
+                    Table.MenuType.SingleSelection,
+                    Table.MenuType.MultiSelection
                   ],
                   keyStroke: 'delete'
                 },
@@ -152,8 +152,8 @@ export default (): FormModel => ({
                   text: '${textKey:ToggleRowEnabled}',
                   inheritAccessibility: false,
                   menuTypes: [
-                    Table.MenuTypes.SingleSelection,
-                    Table.MenuTypes.MultiSelection
+                    Table.MenuType.SingleSelection,
+                    Table.MenuType.MultiSelection
                   ]
                 }
               ]

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTableFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTableFormModel.ts
@@ -100,7 +100,7 @@ export default (): FormModel => ({
                   id: 'DeleteRowMenu',
                   objectType: Menu,
                   text: '${textKey:DeleteRow}',
-                  menuTypes: [Table.MenuTypes.SingleSelection, Table.MenuTypes.MultiSelection],
+                  menuTypes: [Table.MenuType.SingleSelection, Table.MenuType.MultiSelection],
                   keyStroke: 'delete'
                 }
               ]

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tree/TreeFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tree/TreeFormModel.ts
@@ -53,8 +53,8 @@ export default (): FormModel => ({
                   objectType: Menu,
                   text: '${textKey:DeleteNode}',
                   menuTypes: [
-                    Tree.MenuTypes.SingleSelection,
-                    Tree.MenuTypes.MultiSelection
+                    Tree.MenuType.SingleSelection,
+                    Tree.MenuType.MultiSelection
                   ],
                   keyStroke: 'delete'
                 },

--- a/docs/modules/migration/partials/migration-guide-23.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-23.2.adoc
@@ -287,3 +287,29 @@ The `Form.load` and `Form.save` methods now automatically include a busy indicat
 Custom busy indicators for these two operations (e.g. when performing a Rest call) can therefore be removed.
 
 The method `Session.setBusy` was moved to `Desktop.setBusy`. So instead of calling `session.setBusy(...)` use `session.desktop.setBusy(...)`.
+
+=== MenuTypes
+
+The MenuType constants and types were renamed from `MenuTypes` to `MenuType`:
+
+Constants:
+
+* `Calendar.MenuTypes` -> `Calendar.MenuType`
+* `ImageField.MenuTypes` -> `ImageField.MenuType`
+* `Planner.MenuTypes` -> `Planner.MenuType`
+* `TabBox.MenuTypes` -> `TabBox.MenuType`
+* `Table.MenuTypes` -> `Table.MenuType`
+* `TileGrid.MenuTypes` -> `TileGrid.MenuType`
+* `Tree.MenuTypes` -> `Tree.MenuType`
+* `ValueField.MenuTypes` -> `ValueField.MenuType`
+
+Types:
+
+* `CalendarMenuTypes` -> `CalendarMenuType`
+* `ImageFieldMenuTypes` -> `ImageFieldMenuType`
+* `PlannerMenuTypes` -> `PlannerMenuType`
+* `TabBoxMenuTypes` -> `TabBoxMenuType`
+* `TableMenuTypes` -> `TableMenuType`
+* `TileGridMenuTypes` -> `TileGridMenuType`
+* `TreeMenuTypes` -> `TreeMenuType`
+* `ValueFieldMenuTypes` -> `ValueFieldMenuType`

--- a/docs/modules/releasenotes/partials/release-notes-23.2.adoc
+++ b/docs/modules/releasenotes/partials/release-notes-23.2.adoc
@@ -114,7 +114,7 @@ Refer to the xref:migration:migration-guide.adoc#form-error-handling[Migration G
 ==== Default menuTypes
 
 Default menuTypes have been added to several widgets.
-This means that e.g. the `Table` treats a menu without a menuType as if it had set `Table.MenuTypes.EmptySpace`.
+This means that e.g. the `Table` treats a menu without a menuType as if it had set `Table.MenuType.EmptySpace`.
 For more information about the default menuTypes see xref:technical-guide:user-interface/widget-reference.adoc#menu-types[MenuTypes].
 
 === SmartFields: Error-Handling for Key-Lookups

--- a/docs/modules/technical-guide/pages/user-interface/widget-reference.adoc
+++ b/docs/modules/technical-guide/pages/user-interface/widget-reference.adoc
@@ -326,26 +326,26 @@ Please refer to the respective container for the available menu types and their 
 Most widgets specify some default menuTypes. Menus without any menuTypes are treated as if these default menuTypes are set. The defaults are:
 
 * `Calendar`
-** `Calendar.MenuTypes.EmptySpace`
+** `Calendar.MenuType.EmptySpace`
 * `ImageField`
-** `ImageField.MenuTypes.ImageUrl`
-** `ImageField.MenuTypes.Null`
+** `ImageField.MenuType.ImageUrl`
+** `ImageField.MenuType.Null`
 * `Planner`
-** `Planner.MenuTypes.EmptySpace`
+** `Planner.MenuType.EmptySpace`
 * `Table`
-** `Table.MenuTypes.EmptySpace`
+** `Table.MenuType.EmptySpace`
 * `TileGrid`
-** `TileGrid.MenuTypes.EmptySpace`
+** `TileGrid.MenuType.EmptySpace`
 * `Tree`
-** `Tree.MenuTypes.EmptySpace`
+** `Tree.MenuType.EmptySpace`
 * `ValueField`
-** `ValueField.MenuTypes.NotNull`
-** `ValueField.MenuTypes.Null`
+** `ValueField.MenuType.NotNull`
+** `ValueField.MenuType.Null`
 
 === ValueField
 
-The `ValueField` support the menu types `ValueField.MenuTypes.Null` and `ValueField.MenuTypes.NotNull`.
-This means that the `ValueField` will only display menus with `ValueField.MenuTypes.Null` if the value is `null` or those with `ValueField.MenuTypes.NotNull` if the value is set.
+The `ValueField` support the menu types `ValueField.MenuType.Null` and `ValueField.MenuType.NotNull`.
+This means that the `ValueField` will only display menus with `ValueField.MenuType.Null` if the value is `null` or those with `ValueField.MenuType.NotNull` if the value is set.
 
 Menus added to a `ValueField` that need to be visible all the time do not need to specify all possible menu types.
 The `ValueField` will treat a menu without menu types as if it had set all menu types and therefore will always display it.
@@ -365,7 +365,7 @@ import {Menu, ValueField} from '@eclipse-scout/core';
     text: 'Visible if value is null',
     objectType: Menu,
     menuTypes: [
-      ValueField.MenuTypes.Null
+      ValueField.MenuType.Null
     ]
   }
 ]
@@ -373,4 +373,4 @@ import {Menu, ValueField} from '@eclipse-scout/core';
 
 === ImageField
 
-The `ImageField` supports the menu types `ImageField.MenuTypes.ImageUrl` and `ImageField.MenuTypes.Null`.
+The `ImageField` supports the menu types `ImageField.MenuType.ImageUrl` and `ImageField.MenuType.Null`.


### PR DESCRIPTION
constants:
* Calendar.MenuTypes -> Calendar.MenuType
* ImageField.MenuTypes -> ImageField.MenuType
* Planner.MenuTypes -> Planner.MenuType
* TabBox.MenuTypes -> TabBox.MenuType
* Table.MenuTypes -> Table.MenuType
* TileGrid.MenuTypes -> TileGrid.MenuType
* Tree.MenuTypes -> Tree.MenuType
* ValueField.MenuTypes -> ValueField.MenuType types:
* CalendarMenuTypes -> CalendarMenuType
* ImageFieldMenuTypes -> ImageFieldMenuType
* PlannerMenuTypes -> PlannerMenuType
* TabBoxMenuTypes -> TabBoxMenuType
* TableMenuTypes -> TableMenuType
* TileGridMenuTypes -> TileGridMenuType
* TreeMenuTypes -> TreeMenuType
* ValueFieldMenuTypes -> ValueFieldMenuType