### PR TITLE
338668: Cleanup CssClasses hierarchy and constants

### DIFF
--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarFieldForm.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.scout.rt.client.IClientSession;
-import org.eclipse.scout.rt.client.ui.CssClasses;
 import org.eclipse.scout.rt.client.ui.action.menu.AbstractMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.CalendarMenuType;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
@@ -37,6 +36,7 @@ import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.SleepUtil;
 import org.eclipse.scout.rt.platform.util.TriState;
 import org.eclipse.scout.rt.platform.util.date.DateUtility;
+import org.eclipse.scout.rt.shared.CssClasses;
 import org.eclipse.scout.rt.shared.services.common.calendar.CalendarAppointment;
 import org.eclipse.scout.rt.shared.services.common.calendar.CalendarItemDescriptionElement;
 import org.eclipse.scout.rt.shared.services.common.calendar.ICalendarAppointment;

--- a/docs/modules/migration/partials/migration-guide-23.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-23.2.adoc
@@ -237,6 +237,12 @@ charset = latin1 # latin1 = ISO-8859-1
 
 Charset for `[*]` should already be set to `charset = utf-8`.
 
+== CssClasses interface
+
+The interface `org.eclipse.scout.rt.client.ui.CssClasses` was moved to `org.eclipse.scout.rt.shared.CssClasses`.
+The old interface was left and marked `@Deprecated` for release 23/2 and will be removed in a future release.
+Change your imports to the moved interface in order to avoid deprecation warnings.
+
 == Scout JS
 
 === Multi Dimension Support


### PR DESCRIPTION
Moved org.eclipse.scout.rt.client.ui.CssClasses to org.eclipse.scout.rt.shared.CssClasses