### PR TITLE
TooltipForm: remove post validate function

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tooltip/TooltipForm.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/tooltip/TooltipForm.ts
@@ -54,7 +54,6 @@ export class TooltipForm extends Form {
     if (this.tooltip) {
       this.tooltip.$anchor = this.widget('OpenTooltipButton').$field;
       this.tooltip.render();
-      this.session.layoutValidator.schedulePostValidateFunction(() => this.tooltip.position());
     }
   }
 


### PR DESCRIPTION
The tooltip adds the same post validate function itself while it is being rendered.