### PR TITLE
Adjust documentation for inverted property aliases

### DIFF
--- a/docs/modules/technical-guide/pages/user-interface/multi-dimensions.adoc
+++ b/docs/modules/technical-guide/pages/user-interface/multi-dimensions.adoc
@@ -60,7 +60,7 @@ In that case, you can set the alias to `inverted` as follows:
 
 [source,typescript]
 ----
-this._addPropertyDimensionAlias('enabled', 'locked', true);
+this._addPropertyDimensionAlias('enabled', 'locked', {inverted: true});
 ----
 
 == Scout Classic


### PR DESCRIPTION
The API for property dimension aliases has changed. This commit adjusts the corresponding documentation.