### PR TITLE
Map properties: improve support for JSON format

### DIFF
--- a/docs/modules/technical-guide/pages/common-concepts/platform.adoc
+++ b/docs/modules/technical-guide/pages/common-concepts/platform.adoc
@@ -302,7 +302,7 @@ To still allow overriding of such properties, the following lookup rules are app
 . An uppercase match where periods are replaced by underscores (`MY_PROPERTY`)
 
 When it comes to working with String list or map value config properties (subclasses of `org.eclipse.scout.rt.platform.config.AbstractMapConfigProperty` or `org.eclipse.scout.rt.platform.config.AbstractStringListConfigProperty`), there's also some special mechanic to consider in terms of providing or overriding property list or map values using environment variables.
-Since it is not possible to reliably retrieve the original list/map key from an environment variable (again, due to the restrictions mentioned above), property map values may be supplied using environment variables whose value is a JSON object string:
+Since it is not possible to reliably retrieve the original list/map key from an environment variable (again, due to the restrictions mentioned above), property map values may be supplied as a JSON object string:
 
 [source]
 ----
@@ -310,16 +310,25 @@ my_map_property={"map-key-01": "value-01", "map-key-02": "value-02", "map-key-03
 my_list_property={"0": "value-01", "1": "value-02", "2": null}
 ----
 
-The following rules apply, when such environment variables are read:
+The usage of a JSON object string for a map/list property is not restricted to only environment variables but can be used within system properties or a properties file too.
+
+The following rules apply, when such properties are read:
+
 * property map key/value pairs are added from the JSON object to the property map, overriding keys already being defined by sources of lower precedence (e.g. config.properties file)
 * a JSON object attribute value of "null" will remove a key potentially being defined by sources of lower precedence
+* a property value given by the [] pattern will override the value given by a JSON object string defined by the same source. Example within the same source (e.g. config.properties file):
+** `my.map.property={"map-key-01": "value-01", "map-key-02": "value-02"}`
+** `my.map.property[map-key-02]=overridden-value-02`
+** Results in the value `overridden-value-02 for `map-key-02`
 
 The parsing of JSON object strings is abstracted away using the new `org.eclipse.scout.rt.platform.config.IJsonPropertyReader` interface as parsing JSON strings is not implemented in the platform itself.
 However, there is a default implementation of this interface available in org.eclipse.scout.rt.dataobject which uses the `org.eclipse.scout.rt.platform.dataobject.IDataObjectMapper` feature to deserialize the JSON string into a Java Map.
 In order to use this, an implementation of the `IDataObjectMapper` interface is also required (e.g. `org.eclipse.scout.rt.jackson.dataobject.JacksonDataObjectMapper`).
 So in case you want to use this feature, you have to define
+
 * org.eclipse.scout.rt:org.eclipse.scout.rt.dataobject
 * org.eclipse.scout.rt:org.eclipse.scout.rt.jackson
+
 as new dependencies of your application aggregator module (if they are not already present).
 
 


### PR DESCRIPTION
JSON format for map properties was so far only supported for environment variables. Now there is support for properties by properties file and system properties too.

364149