### PR TITLE
Maven build: only add phase binding for Google Jib on active profile

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.server.app.image/pom.xml
+++ b/code/contacts/org.eclipse.scout.contacts.server.app.image/pom.xml
@@ -26,6 +26,7 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <configuration>

--- a/code/contacts/org.eclipse.scout.contacts.ui.html.app.image/pom.xml
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html.app.image/pom.xml
@@ -26,6 +26,7 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <configuration>

--- a/code/contacts/org.eclipse.scout.contacts/pom.xml
+++ b/code/contacts/org.eclipse.scout.contacts/pom.xml
@@ -84,6 +84,29 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>exec.docker.image</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <!-- phase binding required for .app.image module to build and publish docker image -->
+              <groupId>com.google.cloud.tools</groupId>
+              <artifactId>jib-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>build</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -98,20 +121,6 @@
               <headerDefinition>${project.basedir}/../../../license_files/scoutLicenceHeaderJava.xml</headerDefinition>
             </headerDefinitions>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <!-- required for .app.image module to build and publish docker image -->
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>build</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app.image/pom.xml
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app.image/pom.xml
@@ -26,6 +26,7 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <configuration>

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app.image/pom.xml
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app.image/pom.xml
@@ -26,6 +26,7 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Google Jib goal 'build' is bound to phase 'package' via profile 'exec.docker.image' -->
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <configuration>

--- a/code/widgets/org.eclipse.scout.widgets/pom.xml
+++ b/code/widgets/org.eclipse.scout.widgets/pom.xml
@@ -86,6 +86,29 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>exec.docker.image</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <!-- phase binding required for .app.image module to build and publish docker image -->
+              <groupId>com.google.cloud.tools</groupId>
+              <artifactId>jib-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>package</phase>
+                  <goals>
+                    <goal>build</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -100,20 +123,6 @@
               <headerDefinition>${project.basedir}/../../../license_files/scoutLicenceHeaderJava.xml</headerDefinition>
             </headerDefinitions>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <!-- required for .app.image module to build and publish docker image -->
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>jib-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>build</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Google Jib builds the docker image and requires additional configuration (e.g. valid registry to push images to). A build via root pom.xml involving all modules must be executable. Therefore, Google Jib must only be triggered for the .app.image modules if profile 'exec.docker.image' is active. This is achieved by binding the Google Jib goal 'build' to the 'package' phase only if the profile 'exec.docker.image' is active. This enables to avoid profile checks within the .app.image modules itself.

375115