### PR TITLE
Selenium tests: remove exclusion for jetty-webapp

### DIFF
--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app.selenium/pom.xml
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app.selenium/pom.xml
@@ -59,13 +59,6 @@
     <dependency>
       <groupId>org.eclipse.scout.widgets</groupId>
       <artifactId>org.eclipse.scout.widgets.ui.html.app</artifactId>
-      <exclusions>
-        <!-- exclusions required because for running in an embedded jetty, we must not include jetty -->
-        <exclusion>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-webapp</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
org.eclipse.scout.rt.app.Application is a bean und when Jandex is initialized, that class is loaded. Because it contains imports to classes excluded via jetty-webapp (e.g. org.eclipse.jetty.servlet.ServletContextHandler), loading will fail and result in a logged warning (no further issues). Test execution works correctly even without the exclusion of jetty-webapp (Scout App/Jetty is not started, thus no harm there).

378970