### PR TITLE
Avoid dragging images in tables

### DIFF
--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/template/formfield/AbstractFileTableField.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/template/formfield/AbstractFileTableField.java
@@ -240,7 +240,10 @@ public abstract class AbstractFileTableField extends AbstractTableField<Table> {
           BinaryResource value = getResourceColumn().getValue(row);
           if (value != null) {
             addAttachment(value);
-            cell.setText(HTML.imgByBinaryResource(value.getFilename()).cssClass("table-cell-html-image").toHtml());
+            cell.setText(HTML.imgByBinaryResource(value.getFilename())
+                .cssClass("table-cell-html-image")
+                .addAttribute("draggable", "false") // avoid conflict with table selection handler
+                .toHtml());
           }
         }
       }


### PR DESCRIPTION
When clicking on an image inside a table and moving the mouse while the button is pressed, the image is dragged while at the same time the table selection is updated. This is confusing. Because the table selection behavior is more likely to what the user wanted, disable the default browser behavior by adding the attribute "draggable=false" to images.