### PR TITLE
ChartFieldForm

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartColorModeLookupCall.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartColorModeLookupCall.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import {StaticLookupCall} from '@eclipse-scout/core';
+import {ChartColorMode} from '@eclipse-scout/chart';
+
+export class ChartColorModeLookupCall extends StaticLookupCall<string> {
+
+  constructor() {
+    super();
+  }
+
+  protected override _data(): any[] {
+    return ChartColorModeLookupCall.DATA;
+  }
+
+  static DATA = [
+    [ChartColorMode.AUTO, 'Auto'],
+    [ChartColorMode.DATASET, 'Dataset'],
+    [ChartColorMode.DATA, 'Data']
+  ];
+}

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldForm.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldForm.ts
@@ -322,7 +322,7 @@ export class ChartFieldForm extends Form {
       });
       this._setChartConfig(config);
     });
-    accordingToValuesCheckbox.setValue(((this._getChartConfig().options || {}).salesfunnel || {}).normalized || false);
+    accordingToValuesCheckbox.setValue(scout.nvl(this._getChartConfig().options?.salesfunnel?.normalized || true));
 
     this.fulfillmentStartValuePropertyCheckbox = this.widget('FulfillmentStartValuePropertyCheckbox');
 

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldForm.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldForm.ts
@@ -215,6 +215,21 @@ export class ChartFieldForm extends Form {
       this._setChartConfig(config);
     });
 
+    const legendPointsVisibleCheckBox = this.widget('LegendPointsVisibleCheckBox');
+    legendPointsVisibleCheckBox.setValue(this._getChartConfig().options?.plugins?.legend?.pointsVisible);
+    legendPointsVisibleCheckBox.on('propertyChange:value', event => {
+      const config = $.extend(true, {}, this._getChartConfig(), {
+        options: {
+          plugins: {
+            legend: {
+              pointsVisible: event.newValue
+            }
+          }
+        }
+      });
+      this._setChartConfig(config);
+    });
+
     let tooltipsEnabledBox = this.widget('TooltipsEnabledBox');
     tooltipsEnabledBox.setValue((((this._getChartConfig().options || {}).plugins || {}).tooltip || {}).enabled as boolean);
     tooltipsEnabledBox.on('propertyChange:value', event => {
@@ -675,6 +690,7 @@ export class ChartFieldForm extends Form {
       checkableCheckBox.setEnabled(!scout.isOneOf(type, Chart.Type.SALESFUNNEL, Chart.Type.FULFILLMENT, Chart.Type.SPEEDO, Chart.Type.VENN));
       legendVisibleBox.setEnabled(!scout.isOneOf(type, Chart.Type.SALESFUNNEL, Chart.Type.FULFILLMENT, Chart.Type.SPEEDO, Chart.Type.VENN));
       legendClickableCheckBox.setEnabled(!scout.isOneOf(type, Chart.Type.SALESFUNNEL, Chart.Type.FULFILLMENT, Chart.Type.SPEEDO, Chart.Type.VENN));
+      legendPointsVisibleCheckBox.setEnabled(!scout.isOneOf(type, Chart.Type.SALESFUNNEL, Chart.Type.FULFILLMENT, Chart.Type.SPEEDO, Chart.Type.VENN));
       datalabelsVisibleCheckBox.setEnabled(!scout.isOneOf(type, Chart.Type.SALESFUNNEL, Chart.Type.FULFILLMENT, Chart.Type.SPEEDO, Chart.Type.VENN));
       xAxisStackedCheckBox.setEnabled(scout.isOneOf(type, Chart.Type.BAR, Chart.Type.BAR_HORIZONTAL, Chart.Type.LINE, Chart.Type.COMBO_BAR_LINE));
       yAxisStackedCheckBox.setEnabled(scout.isOneOf(type, Chart.Type.BAR, Chart.Type.BAR_HORIZONTAL, Chart.Type.LINE, Chart.Type.COMBO_BAR_LINE));

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
@@ -13,8 +13,8 @@ import {
 } from '@eclipse-scout/core';
 import {Chart, ChartColorMode, ChartField, ChartFieldTile, ChartPosition, ChartType, GreenAreaPosition} from '@eclipse-scout/chart';
 import {
-  ChartTypeLookupCall, ColorSchemeLookupCall, EventsTab, EventsTabWidgetMap, FormFieldPropertiesBox, FormFieldPropertiesBoxWidgetMap, GridDataBox, GridDataBoxWidgetMap, LegendPositionLookupCall, SpeedoGreenAreaPositionLookupCall,
-  ValuesProviderLookupCall, WidgetActionsBox, WidgetActionsBoxWidgetMap
+  ChartColorModeLookupCall, ChartTypeLookupCall, ColorSchemeLookupCall, CustomColorMode, EventsTab, EventsTabWidgetMap, FormFieldPropertiesBox, FormFieldPropertiesBoxWidgetMap, GridDataBox, GridDataBoxWidgetMap, LegendPositionLookupCall,
+  SpeedoGreenAreaPositionLookupCall, ValuesProviderLookupCall, WidgetActionsBox, WidgetActionsBoxWidgetMap
 } from '../index';
 
 export default (): FormModel => ({
@@ -126,36 +126,45 @@ export default (): FormModel => ({
                       id: 'AutoColorCheckBox',
                       objectType: CheckBoxField,
                       label: 'Auto Color',
-                      labelVisible: false
+                      labelVisible: false,
+                      gridDataHints: {
+                        useUiWidth: true,
+                        weightX: 0
+                      }
                     },
                     {
-                      id: 'ColorModeSelectorField',
-                      objectType: ModeSelectorField<ChartColorMode>,
-                      label: 'Color Mode',
+                      id: 'CustomColorModeSelectorField',
+                      objectType: ModeSelectorField<CustomColorMode>,
+                      label: 'Custom color Mode',
                       labelVisible: false,
+                      enabled: false,
                       modeSelector: {
                         id: 'ModeSelector',
-                        objectType: ModeSelector<ChartColorMode>,
+                        objectType: ModeSelector<CustomColorMode>,
                         modes: [
                           {
                             id: 'Dataset',
-                            objectType: Mode<ChartColorMode>,
+                            objectType: Mode<CustomColorMode>,
                             text: 'Dataset',
-                            ref: ChartColorMode.DATASET
+                            ref: CustomColorMode.DATASET
                           },
                           {
                             id: 'Data',
-                            objectType: Mode<ChartColorMode>,
+                            objectType: Mode<CustomColorMode>,
                             text: 'Data',
-                            ref: ChartColorMode.DATA
+                            ref: CustomColorMode.DATA
                           },
                           {
-                            id: 'Auto',
-                            objectType: Mode<ChartColorMode>,
-                            text: 'Auto',
-                            ref: ChartColorMode.AUTO
+                            id: 'Element',
+                            objectType: Mode<CustomColorMode>,
+                            text: 'Element',
+                            ref: CustomColorMode.ELEMENT
                           }
                         ]
+                      },
+                      gridDataHints: {
+                        fillHorizontal: false,
+                        horizontalAlignment: 1
                       }
                     }
                   ]
@@ -278,6 +287,14 @@ export default (): FormModel => ({
                   label: 'Chart Scheme',
                   labelPosition: FormField.LabelPosition.TOP,
                   lookupCall: ColorSchemeLookupCall,
+                  displayStyle: 'dropdown'
+                },
+                {
+                  id: 'ColorModeField',
+                  objectType: SmartField<ChartColorMode>,
+                  label: 'Color Mode',
+                  labelPosition: FormField.LabelPosition.TOP,
+                  lookupCall: ChartColorModeLookupCall,
                   displayStyle: 'dropdown'
                 },
                 {
@@ -570,11 +587,11 @@ export type ChartFieldFormWidgetMap = {
   'ChartPropertiesBox.LeftBox': GroupBox;
   'AutoColorSequenceBox': SequenceBox;
   'AutoColorCheckBox': CheckBoxField;
-  'ColorModeSelectorField': ModeSelectorField<ChartColorMode>;
-  'ModeSelector': ModeSelector<ChartColorMode>;
-  'Dataset': Mode<ChartColorMode>;
-  'Data': Mode<ChartColorMode>;
-  'Auto': Mode<ChartColorMode>;
+  'CustomColorModeSelectorField': ModeSelectorField<CustomColorMode>;
+  'ModeSelector': ModeSelector<CustomColorMode>;
+  'Dataset': Mode<CustomColorMode>;
+  'Data': Mode<CustomColorMode>;
+  'Element': Mode<CustomColorMode>;
   'ClickableCheckBox': CheckBoxField;
   'CheckableCheckBox': CheckBoxField;
   'AnimatedCheckBox': CheckBoxField;
@@ -593,6 +610,7 @@ export type ChartFieldFormWidgetMap = {
   'ChartPropertiesBox.RightBox': GroupBox;
   'ChartTypeField': SmartField<ChartType>;
   'ColorSchemeField': SmartField<string>;
+  'ColorModeField': SmartField<ChartColorMode>;
   'TensionField': NumberField;
   'GreenAreaPositionField': SmartField<GreenAreaPosition>;
   'SizeOfLargestBubbleField': NumberField;

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
@@ -130,28 +130,28 @@ export default (): FormModel => ({
                     },
                     {
                       id: 'ColorModeSelectorField',
-                      objectType: ModeSelectorField,
+                      objectType: ModeSelectorField<ChartColorMode>,
                       label: 'Color Mode',
                       labelVisible: false,
                       modeSelector: {
                         id: 'ModeSelector',
-                        objectType: ModeSelector,
+                        objectType: ModeSelector<ChartColorMode>,
                         modes: [
                           {
                             id: 'Dataset',
-                            objectType: Mode,
+                            objectType: Mode<ChartColorMode>,
                             text: 'Dataset',
                             ref: ChartColorMode.DATASET
                           },
                           {
                             id: 'Data',
-                            objectType: Mode,
+                            objectType: Mode<ChartColorMode>,
                             text: 'Data',
                             ref: ChartColorMode.DATA
                           },
                           {
                             id: 'Auto',
-                            objectType: Mode,
+                            objectType: Mode<ChartColorMode>,
                             text: 'Auto',
                             ref: ChartColorMode.AUTO
                           }
@@ -189,6 +189,13 @@ export default (): FormModel => ({
                   objectType: CheckBoxField,
                   label: 'Legend clickable',
                   tooltipText: 'Datasets can be shown and hidden using the legend',
+                  labelVisible: false
+                },
+                {
+                  id: 'LegendPointsVisibleCheckBox',
+                  objectType: CheckBoxField,
+                  label: 'Legend points visible',
+                  tooltipText: 'Show the colored points in the legend',
                   labelVisible: false
                 },
                 {
@@ -259,7 +266,7 @@ export default (): FormModel => ({
               fields: [
                 {
                   id: 'ChartTypeField',
-                  objectType: SmartField,
+                  objectType: SmartField<ChartType>,
                   label: 'Chart Type',
                   labelPosition: FormField.LabelPosition.TOP,
                   lookupCall: ChartTypeLookupCall,
@@ -267,7 +274,7 @@ export default (): FormModel => ({
                 },
                 {
                   id: 'ColorSchemeField',
-                  objectType: SmartField,
+                  objectType: SmartField<string>,
                   label: 'Chart Scheme',
                   labelPosition: FormField.LabelPosition.TOP,
                   lookupCall: ColorSchemeLookupCall,
@@ -287,7 +294,7 @@ export default (): FormModel => ({
                 },
                 {
                   id: 'GreenAreaPositionField',
-                  objectType: SmartField,
+                  objectType: SmartField<GreenAreaPosition>,
                   label: 'Green area position',
                   labelPosition: FormField.LabelPosition.TOP,
                   lookupCall: SpeedoGreenAreaPositionLookupCall,
@@ -317,7 +324,7 @@ export default (): FormModel => ({
                 },
                 {
                   id: 'LegendPositionField',
-                  objectType: SmartField,
+                  objectType: SmartField<ChartPosition>,
                   label: 'Legend position',
                   labelPosition: FormField.LabelPosition.TOP,
                   lookupCall: LegendPositionLookupCall,
@@ -484,7 +491,7 @@ export default (): FormModel => ({
               processButton: false
             }, {
               id: 'ValuesProviderField',
-              objectType: SmartField,
+              objectType: SmartField<number>,
               label: 'Values',
               labelPosition: FormField.LabelPosition.TOP,
               gridDataHints: {
@@ -573,6 +580,7 @@ export type ChartFieldFormWidgetMap = {
   'AnimatedCheckBox': CheckBoxField;
   'LegendVisibleBox': CheckBoxField;
   'LegendClickableCheckBox': CheckBoxField;
+  'LegendPointsVisibleCheckBox': CheckBoxField;
   'TooltipsEnabledBox': CheckBoxField;
   'DatalabelsVisibleCheckBox': CheckBoxField;
   'XAxisStackedCheckBox': CheckBoxField;

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldFormModel.ts
@@ -284,7 +284,7 @@ export default (): FormModel => ({
                 {
                   id: 'ColorSchemeField',
                   objectType: SmartField<string>,
-                  label: 'Chart Scheme',
+                  label: 'Color Scheme',
                   labelPosition: FormField.LabelPosition.TOP,
                   lookupCall: ColorSchemeLookupCall,
                   displayStyle: 'dropdown'

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/index.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/index.ts
@@ -27,6 +27,7 @@ export * from './browserfield/BrowserFieldForm';
 export * from './browserfield/BrowserFieldFormModel';
 export * from './carousel/CarouselForm';
 export * from './carousel/CarouselFormModel';
+export * from './chartfield/ChartColorModeLookupCall';
 export * from './chartfield/ChartFieldForm';
 export * from './chartfield/ChartFieldFormModel';
 export * from './chartfield/ChartTypeLookupCall';

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/ChartFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/ChartFieldForm.java
@@ -1500,6 +1500,54 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             }
           }
 
+          @Order(70)
+          @ClassId("a969ce83-ccbc-49e4-881b-4c8f10438a88")
+          public class LegendPointsVisibleCheckBox extends AbstractBooleanField {
+
+            @Override
+            protected String getConfiguredLabel() {
+              return "Legend Points Visible";
+            }
+
+            @Override
+            protected String getConfiguredTooltipText() {
+              return "Show the colored points in the legend";
+            }
+
+            @Override
+            protected boolean getConfiguredLabelVisible() {
+              return false;
+            }
+
+            @Override
+            protected boolean getConfiguredEnabled() {
+              return false;
+            }
+
+            @Override
+            protected void execInitField() {
+              setValue(getChart().getConfig().isLegendPointsVisible());
+            }
+
+            @Override
+            protected void execChangedValue() {
+              IChartConfig config = getChart().getConfig();
+              config.withLegendPointsVisible(getValue());
+              getChart().setConfig(config);
+            }
+
+            @Override
+            protected Class<? extends IValueField> getConfiguredMasterField() {
+              return ChartTypeField.class;
+            }
+
+            @Override
+            protected void execChangedMasterValue(Object newMasterValue) {
+              setEnabled(ObjectUtility.isOneOf(newMasterValue, IChartType.PIE, IChartType.DOUGHNUT, IChartType.POLAR_AREA, IChartType.RADAR, IChartType.BAR, IChartType.BAR_HORIZONTAL, IChartType.LINE, IChartType.COMBO_BAR_LINE,
+                  IChartType.BUBBLE, IChartType.SCATTER));
+            }
+          }
+
           @Order(80)
           @ClassId("b30ec3b2-e1b7-4e61-9948-219032728e52")
           public class TooltipsEnabledBox extends AbstractBooleanField {

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/ChartFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/ChartFieldForm.java
@@ -105,7 +105,7 @@ import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBo
 import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.CustomChartPropertiesBox;
 import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.FormFieldPropertiesBox;
 import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.LeftBox.AutoColorSequenceBox.AutoColorCheckBox;
-import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.LeftBox.AutoColorSequenceBox.ColorModeSelectorField;
+import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.LeftBox.AutoColorSequenceBox.CustomColorModeSelectorField;
 import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.LeftBox.FulfillmentStartValuePropertyCheckbox;
 import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.LeftBox.TileCheckBox;
 import org.eclipse.scout.widgets.client.ui.forms.ChartFieldForm.MainBox.BottomBox.ChartPropertiesBox.LeftBox.TransparentCheckBox;
@@ -195,8 +195,8 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
     return getFieldByClass(AutoColorCheckBox.class);
   }
 
-  public ColorModeSelectorField getColorModeSelectorField() {
-    return getFieldByClass(ColorModeSelectorField.class);
+  public CustomColorModeSelectorField getCustomColorModeSelectorField() {
+    return getFieldByClass(CustomColorModeSelectorField.class);
   }
 
   public XAxisStackedCheckBox getXAxisStackedCheckBox() {
@@ -927,7 +927,7 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
 
     valueGroups = CollectionUtility.arrayListWithoutNullElements(valueGroups);
 
-    switch (getColorModeSelectorField().getValue()) {
+    switch (getCustomColorModeSelectorField().getValue()) {
       case DATASET:
         valueGroups.forEach(valueGroup -> valueGroup.setColorHexValue(randomHexColor()));
         break;
@@ -941,7 +941,7 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             .collect(Collectors.toList());
         valueGroups.forEach(valueGroup -> valueGroup.setColorHexValue(colorHexValues));
         break;
-      case AUTO:
+      case ELEMENT:
       default:
         valueGroups.forEach(valueGroup -> valueGroup.setColorHexValue(IntStream.range(0, getValueGroupSize.applyAsInt(valueGroup))
             .mapToObj(i -> randomHexColor())
@@ -1220,6 +1220,16 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
               }
 
               @Override
+              protected boolean getConfiguredGridUseUiWidth() {
+                return true;
+              }
+
+              @Override
+              protected double getConfiguredGridWeightX() {
+                return 0;
+              }
+
+              @Override
               protected void execInitField() {
                 setValue(getChart().getConfig().isAutoColor());
               }
@@ -1237,10 +1247,11 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
 
             @Order(20)
             @ClassId("bc19b509-1a51-4f8c-94ea-42d741504bf3")
-            public class ColorModeSelectorField extends AbstractModeSelectorField<ColorMode> {
+            public class CustomColorModeSelectorField extends AbstractModeSelectorField<CustomColorMode> {
+
               @Override
               protected String getConfiguredLabel() {
-                return "Color mode";
+                return "Custom color mode";
               }
 
               @Override
@@ -1249,18 +1260,28 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
               }
 
               @Override
+              protected boolean getConfiguredEnabled() {
+                return false;
+              }
+
+              @Override
+              protected boolean getConfiguredFillHorizontal() {
+                return false;
+              }
+
+              @Override
+              protected int getConfiguredHorizontalAlignment() {
+                return 1;
+              }
+
+              @Override
               protected void execInitField() {
-                setValue(ColorMode.AUTO);
+                setValue(CustomColorMode.ELEMENT);
               }
 
               @Override
               protected void execChangedValue() {
-                var config = getChart().getConfig();
-                config.withColorMode(getValue());
-                getChart().setConfig(config);
-                if (!getAutoColorCheckBox().getValue()) {
-                  renewData();
-                }
+                renewData();
               }
 
               @Override
@@ -1270,48 +1291,48 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
 
               @Override
               protected void execChangedMasterValue(Object newMasterValue) {
-                getModeFor(ColorMode.AUTO).setText(((boolean) newMasterValue) ? "Auto" : "Element");
+                setEnabled(!(boolean) newMasterValue);
               }
 
               @Order(10)
               @ClassId("2624e524-13da-4cca-bd19-225602b1ec03")
-              public class Dataset extends AbstractMode<ColorMode> {
+              public class Dataset extends AbstractMode<CustomColorMode> {
                 @Override
                 protected String getConfiguredText() {
                   return "Dataset";
                 }
 
                 @Override
-                protected ColorMode getConfiguredRef() {
-                  return ColorMode.DATASET;
+                protected CustomColorMode getConfiguredRef() {
+                  return CustomColorMode.DATASET;
                 }
               }
 
               @Order(20)
               @ClassId("e12d1798-a588-43df-9cef-312c8a16eeb9")
-              public class Data extends AbstractMode<ColorMode> {
+              public class Data extends AbstractMode<CustomColorMode> {
                 @Override
                 protected String getConfiguredText() {
                   return "Data";
                 }
 
                 @Override
-                protected ColorMode getConfiguredRef() {
-                  return ColorMode.DATA;
+                protected CustomColorMode getConfiguredRef() {
+                  return CustomColorMode.DATA;
                 }
               }
 
               @Order(30)
               @ClassId("15d4befc-bb47-457b-92a3-98303924b78c")
-              public class Auto extends AbstractMode<ColorMode> {
+              public class Element extends AbstractMode<CustomColorMode> {
                 @Override
                 protected String getConfiguredText() {
-                  return "Auto";
+                  return "Element";
                 }
 
                 @Override
-                protected ColorMode getConfiguredRef() {
-                  return ColorMode.AUTO;
+                protected CustomColorMode getConfiguredRef() {
+                  return CustomColorMode.ELEMENT;
                 }
               }
             }
@@ -2038,6 +2059,55 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             @Override
             protected void execChangedValue() {
               setColorScheme(getValue());
+            }
+          }
+
+          @Order(25)
+          @ClassId("4564b9e0-1a7f-4d31-94be-0c02202ce55d")
+          public class ColorModeField extends AbstractSmartField<ColorMode> {
+
+            @Override
+            protected String getConfiguredLabel() {
+              return "Color Mode";
+            }
+
+            @Override
+            protected byte getConfiguredLabelPosition() {
+              return LABEL_POSITION_TOP;
+            }
+
+            @Override
+            protected String getConfiguredDisplayStyle() {
+              return DISPLAY_STYLE_DROPDOWN;
+            }
+
+            @Override
+            protected Class<? extends ILookupCall<ColorMode>> getConfiguredLookupCall() {
+              return P_ColorModeLookupCall.class;
+            }
+
+            @Override
+            protected void execInitField() {
+              getAutoColorCheckBox().addPropertyChangeListener(IValueField.PROP_VALUE, e -> setEnabled((boolean) e.getNewValue(), "autoColor"));
+              setValue(ColorMode.AUTO);
+            }
+
+            @Override
+            protected void execChangedValue() {
+              IChartConfig config = getChart().getConfig();
+              config.withColorMode(getValue());
+              getChart().setConfig(config);
+            }
+
+            @Override
+            protected Class<? extends IValueField> getConfiguredMasterField() {
+              return ChartTypeField.class;
+            }
+
+            @Override
+            protected void execChangedMasterValue(Object newMasterValue) {
+              setEnabled(ObjectUtility.isOneOf(newMasterValue, IChartType.PIE, IChartType.DOUGHNUT, IChartType.POLAR_AREA, IChartType.RADAR, IChartType.BAR, IChartType.BAR_HORIZONTAL, IChartType.LINE, IChartType.COMBO_BAR_LINE,
+                  IChartType.BUBBLE, IChartType.SCATTER), "chartType");
             }
           }
 
@@ -3451,5 +3521,26 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
       rows.add(new LookupRow<>(IChartConfig.RIGHT, "Right"));
       return rows;
     }
+  }
+
+  @ClassId("922b5a5f-920e-4d99-9802-55715f732134")
+  public static class P_ColorModeLookupCall extends LocalLookupCall<ColorMode> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected List<? extends ILookupRow<ColorMode>> execCreateLookupRows() {
+      var rows = new ArrayList<ILookupRow<ColorMode>>();
+      rows.add(new LookupRow<>(ColorMode.AUTO, "Auto"));
+      rows.add(new LookupRow<>(ColorMode.DATASET, "Dataset"));
+      rows.add(new LookupRow<>(ColorMode.DATA, "Data"));
+      return rows;
+    }
+  }
+
+  public enum CustomColorMode {
+    ELEMENT,
+    DATASET,
+    DATA
   }
 }

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/ChartFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/ChartFieldForm.java
@@ -1970,6 +1970,11 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             }
 
             @Override
+            protected String getConfiguredDisplayStyle() {
+              return DISPLAY_STYLE_DROPDOWN;
+            }
+
+            @Override
             protected Class<? extends ILookupCall<String>> getConfiguredLookupCall() {
               return ChartTypeLookupCall.class;
             }
@@ -2044,6 +2049,11 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             @Override
             protected byte getConfiguredLabelPosition() {
               return LABEL_POSITION_TOP;
+            }
+
+            @Override
+            protected String getConfiguredDisplayStyle() {
+              return DISPLAY_STYLE_DROPDOWN;
             }
 
             @Override
@@ -2401,6 +2411,11 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             @Override
             protected byte getConfiguredLabelPosition() {
               return LABEL_POSITION_TOP;
+            }
+
+            @Override
+            protected String getConfiguredDisplayStyle() {
+              return DISPLAY_STYLE_DROPDOWN;
             }
 
             @Override
@@ -3216,6 +3231,11 @@ public class ChartFieldForm extends AbstractForm implements IAdvancedExampleForm
             @Override
             protected byte getConfiguredLabelPosition() {
               return LABEL_POSITION_TOP;
+            }
+
+            @Override
+            protected String getConfiguredDisplayStyle() {
+              return DISPLAY_STYLE_DROPDOWN;
             }
 
             @Override

--- a/docs/modules/releasenotes/partials/release-notes-24.2.adoc
+++ b/docs/modules/releasenotes/partials/release-notes-24.2.adoc
@@ -161,3 +161,12 @@ image::grid_data_clone.png[]
 === Event for Grid Data Property Change
 
 Form fields and tiles now trigger a property change event whenever the calculated grid data object changes.
+
+== Chart
+
+The chart introduces two new properties:
+
+* `options.colorMode` Determines what parts of the chart data is colored with the same colors.
+* `options.plugins.legend.pointsVisible` Whether the colored points in the legend are visible.
+
+For more information about the Chart widget see xref:technical-guide:user-interface/widget-reference.adoc#chart[Chart].

--- a/docs/modules/technical-guide/pages/user-interface/widget-reference.adoc
+++ b/docs/modules/technical-guide/pages/user-interface/widget-reference.adoc
@@ -73,6 +73,7 @@ Here's how the request for a Scout JS SmartField lookup call could look like. Yo
 }
 ----
 
+[[chart]]
 == Chart
 
 A `Chart` visualizes data in several ways like bars, lines or a pie. The `Chart` has two main properties, a data and a config object.
@@ -90,12 +91,14 @@ In addition to the chart.js-properties we added custom properties, some of them 
 
 * `options.autoColor` Whether the colors should be computed automatically.
 * `options.colorScheme` A specific color scheme for the colors, also inverted ones are possible for dark backgrounds.
+* `options.colorMode` Determines what parts of the chart data is colored with the same colors.
 * `options.transparent` Whether the chart should be transparent or opaque.
 * `options.maxSegments` Max. number of segments for radial charts like pie, doughnut, radar, polar area.
 * `options.clickable` Whether a chart is clickable.
 * `options.checkable` Whether a chart is checkable.
 * `options.otherSegmentClickable` Whether the consolidated others segment is clickable.
 * `options.plugins.legend.clickable` Whether the legend is clickable.
+* `options.plugins.legend.pointsVisible` Whether the colored points in the legend are visible.
 * `options.xLabelMap` and `options.yLabelMap` Label mapping for discrete values.
 * `options.handleResize` Whether the chart should handle resizing itself (not necessary if the containers size is updated).
 * `options.numberFormatter` A custom number formatter, e.g. 1000000 -> 1 Mio. €.


### PR DESCRIPTION
ChartFieldForm: add LegendPointsVisibleCheckBox

Add checkBox to demonstrate new option legendPointsVisible.

390246

---

ChartFieldForm: add separate ColorModeField

Add a new field for the colorMode-property and do not reuse the
colorModeSelectorField that is used to show different styles of custom
colors.

---

ChartFieldForm: several improvements

Set options.salesfunnel.normalized to true in ChartFieldForm.ts.
Change displayStyle of SmartFields in ChartFieldForm.java to dropdown.