### PR TITLE
objects: rename isPlainObject() to isObject()

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldForm.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/chartfield/ChartFieldForm.ts
@@ -521,7 +521,7 @@ export class ChartFieldForm extends Form {
       if (parsedValue) {
         formatted = JSON.stringify(parsedValue, null, 2);
       }
-      if (!formatted || objects.isPlainObject(parsedValue)) {
+      if (!formatted || objects.isObject(parsedValue)) {
         return formatted;
       }
       throw 'Expected JSON type: Object {}';

--- a/code/widgets/org.eclipse.scout.widgets.ui.html/src/main/js/forms/hybrid/PersonDo.ts
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html/src/main/js/forms/hybrid/PersonDo.ts
@@ -40,7 +40,7 @@ export class PersonDo {
     if (objects.isString(stringOrObject)) {
       stringOrObject = JSON.parse(stringOrObject);
     }
-    if (!objects.isPlainObject(stringOrObject)) {
+    if (!objects.isObject(stringOrObject)) {
       return null;
     }
     const personDo = new PersonDo();


### PR DESCRIPTION
The existing isPlainObject actually has the wrong name, it does not check for *plain* objects, just for objects.
Adjusting the behavior would likely break existing code, so there is now a new function called isPojo (short for plain old JavaScript object) with the correct implementation.
The old function isPlainObject is now deprecated and delegates to a new one called isObject with the same implementation.