### PR TITLE
Restoring rudimentary deploy-to-tomcat.adoc

### DIFF
--- a/docs/modules/getstarted/pages/deploy-to-tomcat.adoc
+++ b/docs/modules/getstarted/pages/deploy-to-tomcat.adoc
@@ -1,0 +1,10 @@
+= Deployment to Tomcat
+include::common:partial$_header.adoc[]
+
+// This file is included in order to avoid the error "target of xref
+// not found: 24.1@deploy-to-tomcat.adoc"
+
+A deployment to Tomcat is no longer required.
+See xref:migration:migration-guide.adoc#cha-jettyserver[Former JettyServer for Development Can Be Used in a Productive Environment]
+and xref:migration:migration-guide.adoc#migration-guide-24-1-jetty-removal-of-war-modules[Removal of .war Modules]
+in the migration guide.


### PR DESCRIPTION
(This is a cherry pick of 0fc3840a75f30e685c105668ef41a3c28c8b86c1 in releases/24.1, see  #234. I do not know why it is missing in releases/24.2.)

Without this file, building the site results in the following errors:

[10:58:46.755] ERROR (asciidoctor): target of xref not found: 24.1@deploy-to-tomcat.adoc
    file: docs/modules/getstarted/pages/deploy-to-tomcat.adoc
    source: C:\dev\doc\scout.docs\.git (branch: releases/22.0 | start path: docs)
[10:58:48.890] ERROR (asciidoctor): target of xref not found: 24.1@deploy-to-tomcat.adoc
    file: docs/modules/getstarted/pages/deploy-to-tomcat.adoc
    source: C:\dev\doc\scout.docs\.git (branch: releases/23.2 | start path: docs)

Apparently Antora expects a page to be available in the future.