### PR TITLE
CalendarComponent: Allow empty toDate

### DIFF
--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarComponentForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarComponentForm.java
@@ -141,11 +141,6 @@ public class CalendarComponentForm extends AbstractForm {
       protected String getConfiguredLabel() {
         return "End";
       }
-
-      @Override
-      protected boolean getConfiguredMandatory() {
-        return true;
-      }
     }
 
     @Order(2500)

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarFieldForm.java
@@ -294,13 +294,7 @@ public class CalendarFieldForm extends AbstractForm implements IAdvancedExampleF
             cal.set(HOUR_OF_DAY, 16);
             cal.set(MINUTE, 0);
             start = cal.getTime();
-            calendarAppointment = new CalendarAppointment();
-            calendarAppointment.setItemId(9L);
-            calendarAppointment.setPerson(2L);
-            calendarAppointment.setStart(start);
-            calendarAppointment.setFullDay(false);
-            calendarAppointment.setSubject("Call Frank");
-            calendarAppointment.setCssClass(cssClass);
+            calendarAppointment = new CalendarAppointment(9L, 2L, start, null, false, null, "Call Frank", null, cssClass);
             calendarAppointment.setSubjectLabel("Private Appointment");
             calendarAppointment.setResourceId(BEANS.get(ICalendarService.class).getPrivateCalendar().getResourceId());
             calendarAppointment.getDescriptionElements().add(BEANS.get(CalendarItemDescriptionElement.class).withText("Frank Walter").withIconId(Icons.PersonSolid));

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarFieldForm.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/forms/CalendarFieldForm.java
@@ -290,6 +290,22 @@ public class CalendarFieldForm extends AbstractForm implements IAdvancedExampleF
             calendarAppointment.getDescriptionElements().add(BEANS.get(CalendarItemDescriptionElement.class).withText("Lisa Turner").withIconId(Icons.PersonSolid));
             result.add(calendarAppointment);
 
+            cal.add(DAY_OF_YEAR, 1);
+            cal.set(HOUR_OF_DAY, 16);
+            cal.set(MINUTE, 0);
+            start = cal.getTime();
+            calendarAppointment = new CalendarAppointment();
+            calendarAppointment.setItemId(9L);
+            calendarAppointment.setPerson(2L);
+            calendarAppointment.setStart(start);
+            calendarAppointment.setFullDay(false);
+            calendarAppointment.setSubject("Call Frank");
+            calendarAppointment.setCssClass(cssClass);
+            calendarAppointment.setSubjectLabel("Private Appointment");
+            calendarAppointment.setResourceId(BEANS.get(ICalendarService.class).getPrivateCalendar().getResourceId());
+            calendarAppointment.getDescriptionElements().add(BEANS.get(CalendarItemDescriptionElement.class).withText("Frank Walter").withIconId(Icons.PersonSolid));
+            result.add(calendarAppointment);
+
             result.addAll(m_configuredAppointments);
           }
 


### PR DESCRIPTION
- Add component without toDate to widgets app for testing purposes
- Make endDate not mandatory