### PR TITLE
Remove deprecated meta tag "apple-mobile-web-app-capable"

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.ui.html/src/main/resources/WebContent/includes/head.html
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html/src/main/resources/WebContent/includes/head.html
@@ -1,13 +1,3 @@
-<!--
-  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
-  ~
-  ~ This program and the accompanying materials are made
-  ~ available under the terms of the Eclipse Public License 2.0
-  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
-  ~
-  ~ SPDX-License-Identifier: EPL-2.0
-  -->
-<meta name="apple-mobile-web-app-capable" content="yes"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/src/main/resources/WebContent/includes/head.html
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/src/main/resources/WebContent/includes/head.html
@@ -1,13 +1,3 @@
-<!--
-  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
-  ~
-  ~ This program and the accompanying materials are made
-  ~ available under the terms of the Eclipse Public License 2.0
-  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
-  ~
-  ~ SPDX-License-Identifier: EPL-2.0
-  -->
-<meta name="apple-mobile-web-app-capable" content="yes"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app/src/main/resources/WebContent/includes/head.html
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app/src/main/resources/WebContent/includes/head.html
@@ -1,13 +1,3 @@
-<!--
-  ~ Copyright (c) 2010, 2023 BSI Business Systems Integration AG
-  ~
-  ~ This program and the accompanying materials are made
-  ~ available under the terms of the Eclipse Public License 2.0
-  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
-  ~
-  ~ SPDX-License-Identifier: EPL-2.0
-  -->
-<meta name="apple-mobile-web-app-capable" content="yes"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">

--- a/docs/modules/migration/partials/migration-guide-25.1.adoc
+++ b/docs/modules/migration/partials/migration-guide-25.1.adoc
@@ -140,6 +140,18 @@ The LESS constant `@icon-error` for the xref:technical-guide:user-interface/icon
 _Migration:_
 Search for references to the constant `@icon-error` in your own *.less files and replace it with `@icon-exclamation-mark-circle` where appropriate.
 
+==  Deprecated meta tag "apple-mobile-web-app-capable" removed
+
+The <meta> tag "apple-mobile-web-app-capable" has been deprecated in iOS for several years.
+Chromium-based browsers recently started reporting this with a warning on the console.
+Because the tag had no effect anyway, it can simply be removed.
+
+_Migration:_
+In existing projects, search for the text `<meta name="apple-mobile-web-app-capable" content="yes"/>` in all *.html files and remove it.
+The template in the Scout archetype was updated accordingly, so newly created projects will no longer contain the deprecated tag.
+
+TIP: Mobile browsers will still offer the possibility to add a home screen icon for the application (which will just be a bookmark, opened in the regular browser). To properly configure it as an "app", consider adding a https://developer.mozilla.org/en-US/docs/Web/Manifest[PWA manifest].
+
 == Scout JS
 
 === FormField: use _computeEmpty instead of _updateEmpty


### PR DESCRIPTION
The meta tag "apple-mobile-web-app-capable" has been deprecated in iOS for several years. Chrome recently started reporting this with a warning on the console. Because the meta tag had no effect, we can simply remove it from all apps.

Mobile browsers will still offer the possibility to add a home screen icon for the application (which will just be a bookmark, opened in the regular browser). To properly configure it as an "app", consider adding a PWA manifest (https://developer.mozilla.org/en-US/docs/Web/Manifest).

393084