### PR TITLE
UiNotifications: wait for subscribe

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/rest/UiNotificationForm.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/rest/UiNotificationForm.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -40,30 +40,31 @@ export class UiNotificationForm extends Form {
     });
     messageField.setValue(this._createSampleMessage());
 
-    this.widget('SubscribeButton').on('click', () => {
+    this.widget('SubscribeButton').on('click', async () => {
+      let topic = this.widget('TopicField').value;
       try {
-        uiNotifications.subscribe(this.widget('TopicField').value, this._notificationHandler).then(topic => {
-          this._addLogEntry(`Subscription for topic ${topic} successful, ready to receive messages `);
-        });
-      } catch (e) {
-        this._addLogEntry('Subscribe failed: ' + e.message);
+        topic = await uiNotifications.subscribe(topic, this._notificationHandler);
+        this._addLogEntry(`Subscription for topic ${topic} successful, ready to receive messages `);
+      } catch (error) {
+        this._addLogEntry(`Failed to subscribe for topic ${topic}. Error: ` + (error.message || error.errorDo?.message));
       }
     });
-    this.widget('SubscribeOneButton').on('click', () => {
+    this.widget('SubscribeOneButton').on('click', async () => {
+      let topic = this.widget('TopicField').value;
       try {
-        uiNotifications.subscribeOne(this.widget('TopicField').value, this._notificationHandler).then(topic => {
-          this._addLogEntry(`Subscription for topic ${topic} successful, ready to receive messages `);
-        });
-      } catch (e) {
-        this._addLogEntry('Subscribe failed: ' + e.message);
+        topic = await uiNotifications.subscribeOne(topic, this._notificationHandler);
+        this._addLogEntry(`Subscription for topic ${topic} successful, ready to receive messages `);
+      } catch (error) {
+        this._addLogEntry(`Failed to subscribe for topic ${topic}. Error: ` + (error.message || error.errorDo?.message));
       }
     });
     this.widget('UnsubscribeButton').on('click', () => {
+      let topic = this.widget('TopicField').value;
       try {
-        uiNotifications.unsubscribe(this.widget('TopicField').value, this._notificationHandler);
-        this._addLogEntry(`Unsubscribed from topic ${this.widget('TopicField').value}`);
-      } catch (e) {
-        this._addLogEntry('Unsubscribe failed: ' + e.message);
+        uiNotifications.unsubscribe(topic, this._notificationHandler);
+        this._addLogEntry(`Unsubscribed from topic ${topic}`);
+      } catch (error) {
+        this._addLogEntry(`Failed to unsubscribe from topic ${topic}: ` + error);
       }
     });
     this.widget('SampleMenu').on('action', () => {

--- a/docs/modules/technical-guide/pages/working-with-data/ui-notifications.adoc
+++ b/docs/modules/technical-guide/pages/working-with-data/ui-notifications.adoc
@@ -114,22 +114,26 @@ This will initiate a request to `api/ui-notifications`, which is the REST resour
 The request will return immediately containing information about the last notification per topic, most importantly, the timestamp of the last notification.
 After that handshake process, a new request is initiated and the UI is ready to receive notifications.
 
-In JavaScript, the promise returned by the `subscribe` function will be resolved once the handshake process is successful.
+In JavaScript, the promise returned by the `subscribe` function will be resolved once the handshake process is successful and rejected if the process failed.
 Make sure to wait for that promise to be resolved before doing any other asynchronous operation (e.g. other REST calls) that relate to this specific topic.
 This ensures you won't miss any relevant UI notification that may have been published right after the subscription.
 
 [source,js]
 ----
-uiNotifications.subscribe(topic, handler).then(topic => {
-  // Subscription was successful, add more dependent tasks here
-});
+uiNotifications.subscribe(topic, handler)
+  .then(topic => {
+    // Subscription was successful, add more dependent tasks here
+  })
+  .catch(error => {
+    // Subscription failed, handle error (e.g. using App.get().errorHandler.handle(error))
+  });
 ----
 
 After the handshake, the UI connects again to the UI notification REST resource that will check the registry for new notifications.
 If there are no notifications yet, a listener is added to the registry that will be informed as soon as a new notification is put into the registry.
-This operation is non blocking, this means, no thread is blocked while waiting for new notifications.
+This operation is non-blocking, this means, no thread is blocked while waiting for new notifications.
 The request waits by default for 1 minute (see `scout.uinotification.waitTimeout`).
-After that time, or as soon as a new notification is added, it will be released and a new connection will be reastablished.
+After that time, or as soon as a new notification is added, it will be released and a new connection will be reestablished.
 
 === Multiple Systems
 


### PR DESCRIPTION
The subscribe request needs to be awaited to avoid race conditions and to improve error handling.

Example what happens without waiting for subscribe():
1. Call subscribe(). A notification for that topic would reload a local cache.
2. Subscribe request is still pending.
3. Load data to fill a local cache.
4. Publish a notification to invalidate the cache.
4. Subscribe request now ends. -> The notification is not received because subscribe() finished after
   the notification was published. The local cache is not invalidated
   and contains old data.

Error handling:
Subscribe now rejects the promise if the request fails. Previously, the request was retried but may have failed again resulting in an unsuccessful subscriptions -> notification for that topic were never received.

408087