### PR TITLE
Add value migration handler to remove a DO entity contribution

### DIFF
--- a/docs/modules/releasenotes/partials/release-notes-25.2.adoc
+++ b/docs/modules/releasenotes/partials/release-notes-25.2.adoc
@@ -62,3 +62,8 @@ In order to support the new class-based Data Objects, these functions had to be 
 
 The mechanism that adds signatures to `IId` is now available for the service tunnel.
 For more information see xref:technical-guide:common-concepts/security.adoc#id-signature-service-tunnel[IId signatures in service tunnel].
+
+== Migration handler for deletion of data object contributions
+
+The new `AbstractRemoveDoEntityContributionValueMigrationHandler` can be used when a data object contribution class is completely deleted. +
+This migration handler will remove the contribution with the given type name and type version from the data objects.


### PR DESCRIPTION
- Add AbstractRemoveDoEntityContributionValueMigrationHandler that can be used to remove a DO contribution that has been deleted from the code
- Add IDoEntity#getAllContributions to get all contributions (incl. unknown contributions)
- IDoEntity#getContributions only returns known contributions (i.e. contributions existing in the code)
- This also fixes a ClassCastException when trying to access a contribution of a DO that also contains unknown contributions

404315