### PR TITLE
Cell: add helper functions for cssClass

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTablePropertiesBox.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/table/hierarchical/HierarchicalTablePropertiesBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -45,7 +45,7 @@ export class HierarchicalTablePropertiesBox extends TablePropertiesBox {
     hierarchicalStyleField.on('propertyChange:value', event => this.table.setHierarchicalStyle(event.newValue));
 
     let extendedHierarchyPaddingField = this.widget('ExtendedHierarchyPaddingField');
-    extendedHierarchyPaddingField.setValue(this.table.cssClassAsArray().indexOf('extended-row-level-padding') > -1);
+    extendedHierarchyPaddingField.setValue(this.table.hasCssClass('extended-row-level-padding'));
     extendedHierarchyPaddingField.on('propertyChange:value', event => this.table.toggleCssClass('extended-row-level-padding', event.newValue));
   }
 }

--- a/docs/modules/migration/partials/migration-guide-26.1.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.1.adoc
@@ -89,3 +89,35 @@ To install the Scout SDK into your existing Eclipse IDE, use this P2 update site
 Scout 26.1 requires at least the following:
 
 * Build and runtime of Scout 26.1 require Java 24 (Java 21 support has been dropped). The compiler target level is set to Java 21. We plan to update to Java 25 LTS as soon as it is available.
+
+== Widget.cssClass: API Changes (Scout JS)
+
+The methods to modify the `cssClass` property of the `Widget` were moved to the `styles` utility (see xref:releasenotes:release-notes.adoc#styles-css-class[Release Notes]).
+The API of `setCssClass`, `addCssClass`, `removeCssClass`, `toggleCssClass` and `hasCssClass` remains the same but the method `cssClassAsArray` and the static method `cssClassAsArray` were removed.
+Code using these methods must be migrated as follows:
+
+.old: using the `cssClassAsArray` methods of the `Widget`.
+[source,typescript,opts=novalidate]
+----
+const widget = scout.create(Widget, {
+  // ...
+  cssClass: 'foo bar'
+});
+const widgetCssClassAsArray = widget.cssClassAsArray();
+
+const cssClass = 'foo bar';
+const cssClassAsArray = Widget.cssClassAsArray(cssClass);
+----
+
+.new: using the `cssClassAsArray` methods of the `styles` utility.
+[source,typescript,opts=novalidate]
+----
+const widget = scout.create(Widget, {
+  // ...
+  cssClass: 'foo bar'
+});
+const widgetCssClassAsArray = styles.cssClassAsArray(widget.cssClass);
+
+const cssClass = 'foo bar';
+const cssClassAsArray = styles.cssClassAsArray(cssClass);
+----

--- a/docs/modules/releasenotes/partials/release-notes-26.1.adoc
+++ b/docs/modules/releasenotes/partials/release-notes-26.1.adoc
@@ -35,3 +35,17 @@ WARNING: {NotReleasedWarning}
 // WARNING: {NotReleasedWarning}
 //
 // * <<New Feature (since 26.1.xyz)>>
+
+[[styles-css-class]]
+== Utility to Modify CSS Classes (Scout JS)
+
+The `styles` utility was extended with new methods to modify the `cssClass`-string of objects or check whether a css class is set or not.
+These methods are:
+
+* `addCssClass`: adds one or more css classes
+* `removeCssClass`: removes one or more css classes
+* `toggleCssClass`: toggles, i.e. adds or removes, one or more css classes depending on a condition
+* `hasCssClass`: checks whether one or more css classes are set
+* `cssClassAsArray`: splits a `cssClass`-string into an array of css classes
+
+In addition, similar methods have been added to the `Cell` class to easier query and modify the `cssClass` property: `addCssClass`, `removeCssClass`, `toggleCssClass`, `hasCssClass`.


### PR DESCRIPTION
Adding, removing and toggling css classes was only implemented for widgets. Move to styles utility and use it to implement adding, removing and toggling cssClasses on the Cell.