### PR TITLE
Improve preserveAndSetProperty

### DIFF
--- a/docs/modules/migration/partials/migration-guide-26.1.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.1.adoc
@@ -133,3 +133,8 @@ const widgetCssClassAsArray = styles.cssClassAsArray(widget.cssClass);
 const cssClass = 'foo bar';
 const cssClassAsArray = styles.cssClassAsArray(cssClass);
 ----
+
+== widgets Util: Behavior Change of preserveAndSetProperty (Scout JS)
+
+If you use the function `widgets.preserveAndSetProperty` in your JavaScript code, please make sure that the variable that stores the preserved value is not initialized or initialized to `undefined`.
+If it is initialized to `null`, remove the initialization.


### PR DESCRIPTION
The function only works if the preserved value is initialized to null. This is not intuitive and does not work if the value should be preserved without adjusting the preserver.
Also, it is not possible to preserve null values.

The function now expects the preserved value to be undefined initially.

Migration: if the member that holds the preserved value was initialized with null, remove the initialization so it will be initialized with undefined.

428304