### PR TITLE
Widgets: ensure overview tiles don't cut text

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/desktop/WidgetsOutlineOverview.less
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/desktop/WidgetsOutlineOverview.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,8 +16,13 @@
   & > .tile-grid {
     margin: 30px 0;
 
-    & > .form-field > .field > .label {
-      font-size: @font-size-plus;
+    & > .tile > .form-field > .field {
+      padding-top: 10px;
+      padding-bottom: 10px;
+
+      & > .label {
+        font-size: @font-size-plus;
+      }
     }
   }
 }

--- a/code/widgets/org.eclipse.scout.widgets.ui.html/src/main/js/WidgetsOutline.less
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html/src/main/js/WidgetsOutline.less
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,7 +36,12 @@
     }
   }
 
-  & > .tile-grid > .form-field > .field > .label {
-    font-size: @font-size-plus;
+  & > .tile-grid > .tile > .form-field > .field {
+    padding-top: 10px;
+    padding-bottom: 10px;
+
+    & > .label {
+      font-size: @font-size-plus;
+    }
   }
 }


### PR DESCRIPTION
Currently, if the text of a page is too long, it is not fully readable when shown in an overview tile.

433364