### PR TITLE
Add Order annotation for IDataObjectSerializerProvider impls

### DIFF
--- a/docs/modules/migration/partials/migration-guide-26.1.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.1.adoc
@@ -182,3 +182,14 @@ As part of the move toward a stateless backend server, the API of the session ha
 `AbstractClientSession`:
 
 * `initializeSharedVariables` renamed to the `loadInitialSharedVariables`.
+
+== Data Object Serializer Provider Implementations Supplemented with Order Annotation
+
+The Scout implementation `ScoutDataObjectSerializerProvider` of serializer/deserializer provider interface `IDataObjectSerializerProvider` was supplemented with an `@Order` annotation using value 4500
+to achieve a fixed order when looking up all instances by `BEANS.all(IDataObjectSerializerProvider.class)`.
+
+ACTION: Check custom implementations of `IDataObjectSerializerProvider` interface.
+Default order for bean implementations without `@Order` annotation is 5000, which means your `IDataObjectSerializerProvider` is invoked as last instance.
+Usually this is appropriate if your implementation just adds serializer or deserializers for additional classes.
+
+If you want to override any Scout serializer/deserializer use an order lower than 4500 for your implementation and become the first provider which is invoked.

--- a/docs/modules/technical-guide/pages/working-with-data/data-object.adoc
+++ b/docs/modules/technical-guide/pages/working-with-data/data-object.adoc
@@ -396,8 +396,14 @@ Apart from attribute descriptions, the inventory provides access to type name an
 
 == Extending with custom serializer and deserializer
 
-The application scoped beans `DataObjectSerializers` resp. `DataObjectDeserializers` define the available serializer and deserializer classes used to marshal the data objects.
-Own custom serializer and deserializer implementations can be added by replacing  the corresponding base class and register its own custom serializer or deserializer.
+The application scoped bean `ScoutDataObjectSerializerProvider` defines the available serializer and deserializer classes used to marshal the data objects.
+Own custom serializer and deserializer implementations can be added by implementing an instance of `IDataObjectSerializerProvider`.
+
+Default order for bean implementations without `@Order` annotation is 5000, which means your `IDataObjectSerializerProvider` is invoked as last instance.
+Usually this is appropriate if your implementation just adds serializer or deserializers for additional classes.
+The Scout bean `ScoutDataObjectSerializerProvider` uses order 4500.
+
+If you want to override any Scout serializer/deserializer use an order lower than 4500 for your implementation and become the first provider which is invoked.
 
 == Enumerations within Data Objects
 


### PR DESCRIPTION
IDataObjectSerializerProvider is used by BEANS.all() which uses alphabetical order as default. Add fixed order for main scout serializer provider implementation.