### PR TITLE
Remove user id from server session

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/Desktop.java
+++ b/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/Desktop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ import org.eclipse.scout.contacts.client.common.SearchOutline;
 import org.eclipse.scout.contacts.client.contact.ContactOutline;
 import org.eclipse.scout.contacts.client.organization.OrganizationForm;
 import org.eclipse.scout.contacts.client.person.PersonForm;
+import org.eclipse.scout.rt.client.session.ClientSessionProvider;
 import org.eclipse.scout.rt.client.ui.action.keystroke.IKeyStroke;
 import org.eclipse.scout.rt.client.ui.action.menu.AbstractMenu;
 import org.eclipse.scout.rt.client.ui.action.menu.IMenuType;
@@ -30,7 +31,6 @@ import org.eclipse.scout.rt.platform.config.PlatformConfigProperties.Application
 import org.eclipse.scout.rt.platform.text.TEXTS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.shared.AbstractIcons;
-import org.eclipse.scout.rt.shared.ISession;
 
 //tag::DesktopInit[]
 //tag::quickAccessMenu[]
@@ -174,7 +174,6 @@ public class Desktop extends AbstractDesktop {
     }
     //tag::quickAccessMenu[]
     //tag::DesktopInit[]
-
   }
   //end::quickAccessMenu[]
 
@@ -206,7 +205,6 @@ public class Desktop extends AbstractDesktop {
     protected Class<OptionsForm> getConfiguredForm() {
       return OptionsForm.class;
     }
-
   }
   //end::OptionsMenu[]
 
@@ -233,7 +231,7 @@ public class Desktop extends AbstractDesktop {
 
     @Override
     protected void execInitAction() {
-      setText(ISession.CURRENT.get().getUserId());
+      setText(ClientSessionProvider.currentSession().getUserId());
     }
 
     //tag::DesktopInit[]
@@ -241,7 +239,6 @@ public class Desktop extends AbstractDesktop {
     protected Class<UserForm> getConfiguredForm() {
       return UserForm.class;
     }
-
   }
   //tag::quickAccessMenu[]
 }

--- a/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/UserForm.java
+++ b/code/contacts/org.eclipse.scout.contacts.client/src/main/java/org/eclipse/scout/contacts/client/UserForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,7 +34,6 @@ import org.eclipse.scout.rt.platform.text.TEXTS;
 import org.eclipse.scout.rt.platform.util.CollectionUtility;
 import org.eclipse.scout.rt.platform.util.HexUtility;
 import org.eclipse.scout.rt.platform.util.StringUtility;
-import org.eclipse.scout.rt.shared.ISession;
 import org.eclipse.scout.rt.shared.http.DefaultHttpTransportManager;
 
 import com.google.api.client.http.GenericUrl;
@@ -140,8 +139,8 @@ public class UserForm extends AbstractForm {
 
   private String createHtmlContent() {
     List<CharSequence> menus = CollectionUtility.arrayList(
-      HTML.div(HTML.appLink("application-info", TEXTS.get("ApplicationInformation"))).cssClass("contacts-user-form-link-row"),
-      HTML.div(HTML.appLink("logout", TEXTS.get("Logout"))).cssClass("contacts-user-form-link-row"));
+        HTML.div(HTML.appLink("application-info", TEXTS.get("ApplicationInformation"))).cssClass("contacts-user-form-link-row"),
+        HTML.div(HTML.appLink("logout", TEXTS.get("Logout"))).cssClass("contacts-user-form-link-row"));
     if (!CONFIG.getPropertyValue(ReadOnlyProperty.class)) {
       menus.add(1, HTML.div(HTML.appLink("reset-data", TEXTS.get("ResetData"))).cssClass("contacts-user-form-link-row"));
     }
@@ -158,7 +157,7 @@ public class UserForm extends AbstractForm {
 
     try {
       // Get the email address of the user
-      String emailAddress = StringUtility.trim(String.format("%s@%s", ISession.CURRENT.get().getUserId(), userDomain)).toLowerCase();
+      String emailAddress = StringUtility.trim(String.format("%s@%s", ClientSessionProvider.currentSession().getUserId(), userDomain)).toLowerCase();
 
       // Calculate MD5 Hash of email address
       MessageDigest messageDigest = MessageDigest.getInstance("MD5");

--- a/code/contacts/org.eclipse.scout.contacts.server/src/main/java/org/eclipse/scout/contacts/server/ServerSession.java
+++ b/code/contacts/org.eclipse.scout.contacts.server/src/main/java/org/eclipse/scout/contacts/server/ServerSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@ package org.eclipse.scout.contacts.server;
 
 import org.eclipse.scout.rt.server.AbstractServerSession;
 import org.eclipse.scout.rt.server.session.ServerSessionProvider;
+import org.eclipse.scout.rt.shared.user.UserId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,6 @@ public class ServerSession extends AbstractServerSession {
 
   @Override
   protected void execLoadSession() {
-    LOG.info("initialized server session for user {}", getUserId());
+    LOG.info("initialized server session for user {}", UserId.CURRENT.get());
   }
 }

--- a/code/contacts/org.eclipse.scout.contacts.shared/src/main/java/org/eclipse/scout/contacts/shared/security/AccessControlService.java
+++ b/code/contacts/org.eclipse.scout.contacts.shared/src/main/java/org/eclipse/scout/contacts/shared/security/AccessControlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,11 +12,10 @@ package org.eclipse.scout.contacts.shared.security;
 import org.eclipse.scout.rt.security.AbstractAccessControlService;
 import org.eclipse.scout.rt.security.IAccessControlService;
 import org.eclipse.scout.rt.security.IPermissionCollection;
-import org.eclipse.scout.rt.shared.ISession;
-import org.eclipse.scout.rt.shared.session.Sessions;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
- * {@link IAccessControlService} service that uses {@link ISession#getUserId()} as internal cache key required by
+ * {@link IAccessControlService} service that uses {@link UserId#CURRENT} as internal cache key required by
  * {@link AbstractAccessControlService} implementation.
  * <p>
  * Replace this service at server side to load permission collection. It is <b>not</b> required to implement
@@ -26,7 +25,7 @@ public class AccessControlService extends AbstractAccessControlService<String> {
 
   @Override
   protected String getCurrentUserCacheKey() {
-    return Sessions.getCurrentUserId();
+    return UserId.CURRENT.get();
   }
 
   @Override

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/java/org/eclipse/scout/jswidgets/ui/html/security/AccessControlService.java
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/java/org/eclipse/scout/jswidgets/ui/html/security/AccessControlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.security.AbstractAccessControlService;
 import org.eclipse.scout.rt.security.AllPermissionCollection;
 import org.eclipse.scout.rt.security.IPermissionCollection;
-import org.eclipse.scout.rt.shared.session.Sessions;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
  * Implementation of {@link org.eclipse.scout.rt.security.IAccessControlService}
@@ -22,7 +22,7 @@ public class AccessControlService extends AbstractAccessControlService<String> {
 
   @Override
   protected String getCurrentUserCacheKey() {
-    return Sessions.getCurrentUserId();
+    return UserId.CURRENT.get();
   }
 
   @Override

--- a/code/widgets/org.eclipse.scout.widgets.shared/src/main/java/org/eclipse/scout/widgets/shared/services/AccessControlService.java
+++ b/code/widgets/org.eclipse.scout.widgets.shared/src/main/java/org/eclipse/scout/widgets/shared/services/AccessControlService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@ import org.eclipse.scout.rt.platform.BEANS;
 import org.eclipse.scout.rt.security.AbstractAccessControlService;
 import org.eclipse.scout.rt.security.AllPermissionCollection;
 import org.eclipse.scout.rt.security.IPermissionCollection;
-import org.eclipse.scout.rt.shared.session.Sessions;
+import org.eclipse.scout.rt.shared.user.UserId;
 
 /**
  * Implementation of {@link org.eclipse.scout.rt.security.IAccessControlService}
@@ -22,7 +22,7 @@ public class AccessControlService extends AbstractAccessControlService<String> {
 
   @Override
   protected String getCurrentUserCacheKey() {
-    return Sessions.getCurrentUserId();
+    return UserId.CURRENT.get();
   }
 
   @Override

--- a/docs/modules/migration/partials/migration-guide-26.1.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.1.adoc
@@ -237,6 +237,7 @@ As part of the move toward a stateless backend server, the API of the session ha
 `ISession`:
 
 * `getSharedVariableMap` moved to the `IClientSession`.
+* `getUserId` moved to the `IClientSession`. On server, use the ThreadLocal `UserId.CURRENT` instead.
 
 `IClientSession`:
 
@@ -248,7 +249,7 @@ As part of the move toward a stateless backend server, the API of the session ha
 
 `AbstractClientSession`:
 
-* `initializeSharedVariables` renamed to the `loadInitialSharedVariables`.
+* `initializeSharedVariables` renamed to `loadInitialSharedVariables`.
 
 == Data Object Serializer Provider Implementations Supplemented with Order Annotation
 
@@ -287,3 +288,22 @@ If a test method exceeds a specific runtime duration it is still completed but f
 The default runtime limit is set to three minutes.
 The limit may be increased by setting a higher timeout on the `@Test` annotation.
 The limit is disabled completely when a negative timeout is set on the `@Test` annotation.
+
+== Removed automatic binding for session variables in SQL statements
+
+Previously, SQL queries could reference session variables as bind parameters without explicitly providing their values. For example:
+
+[source,sql]
+----
+SELECT :userId;
+----
+
+In this case, the `:userId` bind was automatically populated from the current session context.
+
+*What Changed:*
+Automatic binding of session variables to SQL bind parameters has been *removed*. Queries now require explicit binding of the session variables during execution.
+
+For compatibility reasons the `userId` bind is still automatically bound with the current user id. But all the other session variables are not automatically bound anymore.
+
+*Action Required:*
+Review and update your queries to explicitly bind the session variables when executing SQL statements.

--- a/docs/modules/migration/partials/migration-guide-26.1.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.1.adoc
@@ -251,6 +251,11 @@ As part of the move toward a stateless backend server, the API of the session ha
 
 * `initializeSharedVariables` renamed to `loadInitialSharedVariables`.
 
+`ServiceTunnelRequest`:
+
+* `getSessionId` removed. Replaced by a custom HTTP Header `X-Scout-Client-Session-Id`.
+* `setSessionId` removed. Replaced by a custom HTTP Header `X-Scout-Client-Session-Id`.
+
 == Data Object Serializer Provider Implementations Supplemented with Order Annotation
 
 The Scout implementation `ScoutDataObjectSerializerProvider` of serializer/deserializer provider interface `IDataObjectSerializerProvider` was supplemented with an `@Order` annotation using value 4500


### PR DESCRIPTION
As part of the move toward a stateless server session, the `userId` has been removed from the server session.

To get the user id for the current run context, the ThreadLocal `UserId.CURRENT` can be used instead.

423389