### PR TITLE
Add new disabled style MASKED

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/common/StatesBox.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/common/StatesBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -73,7 +73,15 @@ export class StatesBox extends GroupBox implements StatesBoxModel {
     });
     this._delegateProperties(readOnlyField, 'enabled', 'enabled-default', 'disabledStyle');
 
-    this.setFields([...this.fields, errorField, disabledField, readOnlyField]);
+    let maskedField = scout.create({
+      ...initModel,
+      label: 'Masked',
+      enabled: false,
+      disabledStyle: Widget.DisabledStyle.MASKED
+    });
+    this._delegateProperties(maskedField, 'enabled', 'enabled-default', 'disabledStyle', 'value', 'displayText');
+
+    this.setFields([...this.fields, errorField, disabledField, readOnlyField, maskedField]);
 
     this.getForm().rootGroupBox.insertMenu({
       id: 'ShowStatesMenu',

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/formfield/DisabledStyleLookupCall.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/formfield/DisabledStyleLookupCall.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ export class DisabledStyleLookupCall extends StaticLookupCall<DisabledStyle> {
 
   static DATA = [
     [Widget.DisabledStyle.DEFAULT, 'default'],
-    [Widget.DisabledStyle.READ_ONLY, 'read only']
+    [Widget.DisabledStyle.READ_ONLY, 'read only'],
+    [Widget.DisabledStyle.MASKED, 'masked']
   ];
 }

--- a/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/template/formfield/DisabledStyleLookupCall.java
+++ b/code/widgets/org.eclipse.scout.widgets.client/src/main/java/org/eclipse/scout/widgets/client/ui/template/formfield/DisabledStyleLookupCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2025 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ public class DisabledStyleLookupCall extends LocalLookupCall<Integer> {
     List<ILookupRow<Integer>> rows = new ArrayList<>();
     rows.add(new LookupRow<>(IFormField.DISABLED_STYLE_DEFAULT, "default"));
     rows.add(new LookupRow<>(IFormField.DISABLED_STYLE_READ_ONLY, "read only"));
+    rows.add(new LookupRow<>(IFormField.DISABLED_STYLE_MASKED, "masked"));
     return rows;
   }
 }


### PR DESCRIPTION
To indicate to a user that a field is displayed empty due to lack of permissions, a new disabled style is added.

#441912