### PR TITLE
Add missing @Path annotation on REST resources

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.rest/src/main/java/org/eclipse/scout/jswidgets/rest/SampleUiNotificationResource.java
+++ b/code/widgets/org.eclipse.scout.jswidgets.rest/src/main/java/org/eclipse/scout/jswidgets/rest/SampleUiNotificationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.scout.rt.api.uinotification.UiNotificationResource;
 import org.eclipse.scout.rt.platform.Replace;
 
+@Path("ui-notifications")
 @Replace
 public class SampleUiNotificationResource extends UiNotificationResource {
 

--- a/docs/modules/migration/partials/migration-guide-26.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.2.adoc
@@ -95,3 +95,13 @@ Scout 26.2 requires at least the following:
 It is recommended that all REST operations which consume a request entity body message have a `Consumes` annotation set to restrict invalid input.
 Therefore, a test has been added which fails if there are such operations which do not have a `Consumes` annotation.
 The `AbstractRestResourceAnnotationTest` has to be extended in your modules to run this test.
+
+== REST resources: Explicit `@Path` annotation required
+
+It is recommended that all REST resource classes explicitly declare a `@Path` annotation.
+
+According to the Jakarta RESTful Web Services specification, JAX-RS annotations — including `@Path` — are not inherited from superclasses or interfaces.
+While Jersey, the implementation we use, does attempt to locate a `@Path` annotation on parent classes, this behavior is not defined by the specification and should not be relied upon.
+
+To ensure compliance, a test has been introduced that fails if any REST resource is missing a `@Path` annotation.
+To activate this validation for your module, extend the `AbstractRestResourceAnnotationTest` class accordingly.


### PR DESCRIPTION
According to the Jakarta specification the inheritance of class or interface annotations of JAX-RS annotations is not supported.

449990