### PR TITLE
Add missing @Path annotation on REST resources

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.rest/src/main/java/org/eclipse/scout/jswidgets/rest/SampleUiNotificationResource.java
+++ b/code/widgets/org.eclipse.scout.jswidgets.rest/src/main/java/org/eclipse/scout/jswidgets/rest/SampleUiNotificationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.scout.rt.api.uinotification.UiNotificationResource;
 import org.eclipse.scout.rt.platform.Replace;
 
+@Path("ui-notifications")
 @Replace
 public class SampleUiNotificationResource extends UiNotificationResource {
 


### PR DESCRIPTION
According to the Jakarta specification the inheritance of class or interface annotations of JAX-RS annotations is not supported.

449990