### PR TITLE
Add missing @Path annotation on REST resources

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.rest/src/main/java/org/eclipse/scout/jswidgets/rest/SampleUiNotificationResource.java
+++ b/code/widgets/org.eclipse.scout.jswidgets.rest/src/main/java/org/eclipse/scout/jswidgets/rest/SampleUiNotificationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.scout.rt.api.uinotification.UiNotificationResource;
 import org.eclipse.scout.rt.platform.Replace;
 
+@Path("ui-notifications")
 @Replace
 public class SampleUiNotificationResource extends UiNotificationResource {
 

--- a/docs/modules/migration/partials/migration-guide-25.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-25.2.adoc
@@ -417,3 +417,14 @@ As part of these adjustments, the associated `SimpleTabAreaLayout` has been modi
 - `overflowTabItemWidth` was renamed to `overflowTabItemSize`
 
 The old attributes are still available but deprecated and will be removed in a future release.
+
+== REST resources: Explicit `@Path` annotation required on subclasses of `AbstractCancellationResource`
+
+All REST resource classes should explicitly declare their own `@Path` annotation.
+
+According to the Jakarta RESTful Web Services specification, JAX-RS annotations — including `@Path` — are not inherited from superclasses or interfaces.
+While Jersey, the implementation we use, does attempt to locate a `@Path` annotation on parent classes, this behavior is not defined by the specification and should not be relied upon.
+
+To align with the specification and avoid relying on non-standard behavior, the `@Path` annotation has been removed from `AbstractCancellationResource`.
+
+If your resource class extends `AbstractCancellationResource`, ensure that you declare an explicit `@Path` annotation on the subclass.


### PR DESCRIPTION
According to the Jakarta specification the inheritance of class or interface annotations of JAX-RS annotations is not supported.

449990