### PR TITLE
Outline: improve lazy expanding

### DIFF
--- a/docs/modules/migration/partials/migration-guide-26.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.2.adoc
@@ -471,3 +471,12 @@ The defaults of the following properties have changed:
 * `gridDataHints.weightY` to `1`
 
 If you use the `WrappedFormField` in your Scout JS code, please verify the layout still looks and behaves as expected.
+
+== ITreeUIFacade.setNodeSelectedAndExpandedFromUI Moved
+
+The method has been moved to `IOutline` and renamed to `drillDown`.
+
+It is called when double-clicking a table row in the detail table of a page to select and expand the corresponding child page.
+But, expanding is actually not desired for table pages, so now only node pages are expanded.
+
+If you need a specific table page or `IJsPage` to be expanded on this operation, you can override the method `IPage.computeExpandOnDrillDown`.


### PR DESCRIPTION
- Set lazyExpandingEnabled to true for Scout JS table pages   Scout JS based table pages should expand lazily by default to make it   consistent with Scout Classic table pages.
- Ensure correct expandedLazy state (Scout JS)   If lazyExpandingEnabled is disabled and the node updated,   expandedLazy state should be set to false as well.
- Don't expand table pages on drill down (Scout Classic)   Currently, a double click on a table row in the detail table of a page   always selects and expands the corresponding child page. This is fine   for node pages, but if a table is expanded that has   lazyExpandingEnabled set to true (default), a + is shown for the page   in the outline but no child page is visible. This is confusing and   also inconsistent to what the NavigateDown button does. This button   does the expanding only for node pages (see Outline.ts#drillDown).   Now, the Java based drillDown does the same as the JS based.
- Moved ITreeUIFacade.setNodeSelectedAndExpandedFromUI to IOutline   and renamed it to drillDown, because it is never called from ui.
- Added IPage.computeExpandOnDrillDown which returns true for node   pages.
- Removed unused property isChildrenVolatile/setChildrenVolatile of   ITreeNode.

337244