### PR TITLE
Use modern viewport meta tag

### DIFF
--- a/code/contacts/org.eclipse.scout.contacts.ui.html/src/main/resources/WebContent/includes/head.html
+++ b/code/contacts/org.eclipse.scout.contacts.ui.html/src/main/resources/WebContent/includes/head.html
@@ -1,4 +1,13 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<!--
+  ~ Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="favicon/apple-touch-icon-60x60.png">

--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/src/main/resources/WebContent/includes/head.html
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html.app/src/main/resources/WebContent/includes/head.html
@@ -1,4 +1,13 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<!--
+  ~ Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="favicon/apple-touch-icon-60x60.png">

--- a/code/widgets/org.eclipse.scout.widgets.ui.html.app/src/main/resources/WebContent/includes/head.html
+++ b/code/widgets/org.eclipse.scout.widgets.ui.html.app/src/main/resources/WebContent/includes/head.html
@@ -1,4 +1,13 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<!--
+  ~ Copyright (c) 2010, 2026 BSI Business Systems Integration AG
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <!-- BEGIN favicon -->
 <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon" sizes="60x60" href="favicon/apple-touch-icon-60x60.png">


### PR DESCRIPTION
Users should be able to zoom the website. However, zooming was already possible on many devices, like desktop browsers and also on iOS because Safari ignores the viewport meta tag.

394505