### PR TITLE
Show info about missing permission on AccessForbiddenException

### DIFF
--- a/code/org.eclipse.scout.docs.snippets/src/main/java/org/eclipse/scout/docs/snippets/AccessSnippet.java
+++ b/code/org.eclipse.scout.docs.snippets/src/main/java/org/eclipse/scout/docs/snippets/AccessSnippet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024 BSI Business Systems Integration AG
+ * Copyright (c) 2010, 2026 BSI Business Systems Integration AG
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.scout.rt.security.AbstractPermission;
 import org.eclipse.scout.rt.security.IPermission;
 
 public class AccessSnippet {
-
 
   //tag::ReadCompanyPermission[]
   public static class ReadCompanyPermission extends AbstractPermission {
@@ -55,11 +54,15 @@ public class AccessSnippet {
   protected void snippets() {
 
     //tag::ACCESS_A[]
-    if (ACCESS.check(new ReadCompanyPermission())) { // <1>
-      throw new AccessForbiddenException(TEXTS.get("YouAreNotAllowedToReadThisData"));
+    ReadCompanyPermission permission = new ReadCompanyPermission();
+    if (!ACCESS.check(permission)) { // <1>
+      throw new AccessForbiddenException(TEXTS.get("YouAreNotAllowedToReadThisData"))
+          .withPermission(permission);
     }
 
     ACCESS.checkAndThrow(new ReadCompanyPermission()); // <2>
+
+    ACCESS.checkAndThrow(new ReadCompanyPermission(), TEXTS.get("YouAreNotAllowedToReadThisData")); // <3>
     //end::ACCESS_A[]
 
     //tag::ACCESS_B[]
@@ -142,6 +145,5 @@ public class AccessSnippet {
   protected interface ICompanyService {
 
     boolean isOwnCompany(UUID companyId);
-
   }
 }

--- a/docs/modules/migration/partials/migration-guide-26.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.2.adoc
@@ -560,3 +560,33 @@ You should find most of them by searching for `objectType: TabBox` and `property
 == Form Field: Renamed _updateEmpty (Scout JS)
 
 The protected method `FormFeld._updateEmpty()` has been made public and renamed to `FormFeld.updateEmpty()`.
+
+== Permission checks
+
+* A new method `ACCESS.checkAndThrow(permission, accessCheckFailedMessage)` has been added that allows to set a custom error message if the permission check fails.
++
+.Previous code
+[source,java,opts=novalidate]
+----
+if (!ACCESS.check(new ReadBakeryOutlinePermission())) {
+  throw new AccessForbiddenException("My special error message");
+}
+----
++
+.New code
+[source,java,opts=novalidate]
+----
+ACCESS.checkAndThrow(new ReadBakeryOutlinePermission(), "My special error message");
+----
+* The `AccessForbiddenException` now includes a permission code – use `.withPermission(p)` when manually throwing an `AccessForbiddenException` caused by a permission check.
++
+.Example of a manually thrown `AccessForbiddenException`
+[source,java,opts=novalidate]
+----
+ReadBakeryOutlinePermission permission = new ReadBakeryOutlinePermission();
+if (!ACCESS.check(permission)) {
+  throw new AccessForbiddenException(TEXTS.get("YouAreNotAllowedToReadThisData"))
+    .withTitle("My special title")
+    .withPermission(permission);
+}
+----

--- a/docs/modules/technical-guide/pages/common-concepts/security.adoc
+++ b/docs/modules/technical-guide/pages/common-concepts/security.adoc
@@ -189,6 +189,7 @@ include::common:example$org.eclipse.scout.docs.snippets/src/main/java/org/eclips
 ----
 <1> Checks permission against granted permissions of current user.
 <2> Checks permission and if this check fails, throw an `AccessForbiddenException` with a default message.
+<3> Checks permission and if this check fails, throw an `AccessForbiddenException` with a custom message.
 
 We can define a default access check failed message for a permission.
 


### PR DESCRIPTION
On a permission check an AccessForbiddenException is thrown. A message is shown to the user with a message like "You are not authorized to execute this action". But the user does not know which permission is missing.

This change adds an error code to the error popup on an AccessForbiddenException to give the user a hint which permission is missing.

326455