### PR TITLE
Simplify System.getEndpointUrl

### DIFF
--- a/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTable.ts
+++ b/code/widgets/org.eclipse.scout.jswidgets.ui.html/src/main/js/page/SamplePageWithTable.ts
@@ -98,7 +98,7 @@ export class SamplePageWithTable extends PageWithTable {
   }
 
   protected override _loadTableData(searchFilter: SamplePageWithTableRestrictionDo): JQuery.Promise<SamplePageWithTableResponse> {
-    const resourceUrl = systems.getOrCreate().getEndpointUrl('samplePageWithTable', 'samplePageWithTable');
+    const resourceUrl = systems.getOrCreate().getEndpointUrl('samplePageWithTable');
     const restriction = this._withMaxRowCountContribution(searchFilter);
     if (this.detailTable.isCustomizable()) {
       let customizerData = this.detailTable.customizer.getCustomizerData() as SampleTableCustomizerDo;

--- a/docs/modules/howtos/pages/scout-js/rest-service-how-to.adoc
+++ b/docs/modules/howtos/pages/scout-js/rest-service-how-to.adoc
@@ -188,7 +188,7 @@ export class PizzaTablePage extends PageWithTable {
   }
 
   protected override _loadTableData(searchFilter: PizzaRestrictionDo): JQuery.Promise<PizzaResponse> {
-    const resourceUrl = systems.getOrCreate().getEndpointUrl('pizza', 'pizza'); // <2>
+    const resourceUrl = systems.getOrCreate().getEndpointUrl('pizza'); // <2>
     const restriction = this._withMaxRowCountContribution(searchFilter); // <3>
     return ajax.postDataObject(resourceUrl + '/list', restriction); // <4>
   }
@@ -228,7 +228,7 @@ export class PizzaRestrictionDo extends BaseDoEntity {
 ----
 
 <1> A small inline model for the PizzaTablePage having two columns. The Table is configured to only load the first 10 Pizzas.
-<2> Gets the URL to the PizzaResource. The second argument is the default value which corresponds to the `@Path` on the `PizzaResource` class.
+<2> Gets the URL to the PizzaResource. The argument is the default url which corresponds to the `@Path` on the `PizzaResource` class.
 <3> Attaches the `MaxRowCountContributionDo` (contains the `maxRowCount` of the table) to the restrictions.
 <4> Send the `POST` to the given URL having the restriction in the body encoded as `JSON`.
 <5> Map a single `PizzaDo` from the response to the column of the table. The mapping is done by index here.

--- a/docs/modules/migration/partials/migration-guide-26.2.adoc
+++ b/docs/modules/migration/partials/migration-guide-26.2.adoc
@@ -590,3 +590,12 @@ if (!ACCESS.check(permission)) {
     .withPermission(permission);
 }
 ----
+
+== Simplify System.getEndpointUrl (Scout JS)
+
+The function `System.getEndpointUrl` only takes one argument now.
+The first one has been removed and only the second argument (default URL) is used for both the endpoint identifier and default URL.
+
+Migrate from `System.getEndpointUrl('name', 'default/url')` to `System.getEndpointUrl('default/url')`.
+
+In case an existing named URL has been replaced using `System.setEndpointUrl('name', 'new/url')` it must be migrated to `System.setEndpointUrl('default/url', 'new/url')`.


### PR DESCRIPTION
getEndpointUrl only takes one argument now. The first one has been removed and only the second argument (default URL) is used for both the endpoint identifier and default URL.

456584