### PR TITLE
Make local lookup calls search the whole text

### DIFF
--- a/docs/modules/releasenotes/partials/release-notes-26.2.adoc
+++ b/docs/modules/releasenotes/partials/release-notes-26.2.adoc
@@ -209,3 +209,8 @@ The `Table` widget can now let users move a row to a different position by simpl
 image::common:table_row_dnd_animation.gif[]
 
 Detailed information on how to use this in your own application can be found in the xref:technical-guide:user-interface/widget-reference.adoc#table-dnd[Technical Guide].
+
+== Local lookup calls: Search the whole text
+
+For local lookup calls (`LocalLookupCall.java` and `StaticLookupCall.ts`), wildcards ar inserted at the beginning and end of the lookup text so that the whole text is searched instead of only the beginning.
+This way, they are unified with the implementation in `LookupHelper.createTextSearchPattern`.


### PR DESCRIPTION
For local lookup calls, wildcards are inserted at the beginning and end
of the lookup text so that the whole text is searched instead of only
the beginning.

420317